### PR TITLE
Close modals when the screen is resized.

### DIFF
--- a/src/Board.svelte
+++ b/src/Board.svelte
@@ -136,6 +136,10 @@
     }
   }
 
+  function onResize() {
+    showNewCardModal = false;
+  }
+
   onMount(async () => {
     // Update on initial load
     await update();
@@ -244,6 +248,8 @@
     }
   }
 </style>
+
+<svelte:window on:resize={onResize} />
 
 <div class="d-flex h-100 flex-column fixed-top fixed-bottom bg-light">
 


### PR DESCRIPTION
This prevents the modal background from persisting when the user switches to mobile view.
fixes #48  