### PR TITLE
Revert "Bump svelte from 3.23.2 to 3.24.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3736,9 +3736,9 @@
       }
     },
     "svelte": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.24.0.tgz",
-      "integrity": "sha512-VFXom6EP2DK83kxy4ZlBbaZklSbZIrpNH3oNXlPYHJUuW4q1OuAr3ZoYbfIVTVYPDgrI7Yq0gQcOhDlAtO4qfw==",
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.23.2.tgz",
+      "integrity": "sha512-hE8GeTM83YVR4GY6/6PeDEcGct4JS5aCi+IYbCAa76oaPSfuF7L85DQYULQxlTK/KPWzw3L1GRGmC3oPG/PQoA==",
       "dev": true
     },
     "svelte-feather-icons": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-serve": "^1.0.1",
     "rollup-plugin-svelte": "^5.2.3",
     "rollup-plugin-terser": "^6.1.0",
-    "svelte": "^3.24.0"
+    "svelte": "^3.0.0"
   },
   "dependencies": {
     "clipboard": "^2.0.6",


### PR DESCRIPTION
Reverts d0x2f/retrograde.js#74

causes ui issues on the splash page