### PR TITLE
feat: add obscure cards toggle (#175)

### DIFF
--- a/cypress/e2e/Menu.cy.js
+++ b/cypress/e2e/Menu.cy.js
@@ -26,6 +26,10 @@ context("Menu", () => {
       .children()
       .first()
       .should("have.attr", "data-checked", "true");
+    cy.get("[data-name=obscure-cards-button]")
+      .children()
+      .first()
+      .should("have.attr", "data-checked", "false");
     cy.get("[data-name=sort-button]")
       .children()
       .first()
@@ -40,6 +44,7 @@ context("Menu", () => {
     cy.get("[data-name=menu-button]").click();
     cy.get("[data-name=cards-open-button]").should("be.visible");
     cy.get("[data-name=voting-open-button]").should("be.visible");
+    cy.get("[data-name=obscure-cards-button]").should("be.visible");
     cy.get("[data-name=sort-button]").should("be.visible");
     cy.get("[data-name=copy-link-button]").should("be.visible");
     cy.get("[data-name=download-csv-button]").should("be.visible");

--- a/cypress/e2e/ObscureCards.cy.js
+++ b/cypress/e2e/ObscureCards.cy.js
@@ -57,10 +57,12 @@ context("ObscureCards", () => {
     });
 
     it("is off by default", () => {
+      cy.get("[data-name=menu-button]").click();
       cy.get("[data-name=obscure-cards-button]")
         .children()
         .first()
         .should("have.attr", "data-checked", "false");
+      cy.get("[data-name=menu-button]").click();
     });
 
     it("can toggle obscure cards on and off", () => {

--- a/cypress/e2e/ObscureCards.cy.js
+++ b/cypress/e2e/ObscureCards.cy.js
@@ -1,0 +1,196 @@
+/// <reference types="cypress" />
+
+function setObscureCards(enabled) {
+  cy.login("owner");
+  cy.visit(boardUrl);
+  cy.get("[data-name=rank]:visible").should("exist");
+  cy.get("[data-name=menu-button]").click();
+  cy.get("[data-name=obscure-cards-button]")
+    .children()
+    .first()
+    .then(($el) => {
+      const current = $el.attr("data-checked") === "true";
+      if (current !== enabled) {
+        cy.intercept("PATCH", "**/boards/**").as("toggleObscure");
+        cy.get("[data-name=obscure-cards-button]").click();
+        cy.wait("@toggleObscure");
+      }
+    });
+  cy.get("[data-name=menu-button]").click();
+}
+
+let boardUrl;
+
+context("ObscureCards", () => {
+  before(() => {
+    cy.login("owner");
+    cy.visit("/");
+    cy.get("[data-name=board-name-input]").type("Obscure Cards Board");
+    cy.get("[data-name=create-button]").click();
+    cy.get("[data-name=create-button]:visible").should("have.length", 0);
+
+    cy.get("[data-name=rank]:visible")
+      .first()
+      .find("[data-name=card-text-input]")
+      .type("Owner card text");
+    cy.get("[data-name=rank]:visible")
+      .first()
+      .find("[data-name=card-author-input]")
+      .type("Owner{enter}");
+    cy.get("[data-name=card]:visible").should("exist");
+
+    cy.url().then((url) => {
+      boardUrl = url;
+    });
+  });
+
+  context("as board owner", () => {
+    beforeEach(() => {
+      cy.login("owner");
+      cy.visit(boardUrl);
+      cy.get("[data-name=rank]:visible").should("exist");
+    });
+
+    it("shows the obscure cards toggle in the menu", () => {
+      cy.get("[data-name=menu-button]").click();
+      cy.get("[data-name=obscure-cards-button]").should("be.visible");
+    });
+
+    it("is off by default", () => {
+      cy.get("[data-name=obscure-cards-button]")
+        .children()
+        .first()
+        .should("have.attr", "data-checked", "false");
+    });
+
+    it("can toggle obscure cards on and off", () => {
+      cy.get("[data-name=menu-button]").click();
+      cy.get("[data-name=obscure-cards-button]").click();
+      cy.get("[data-name=obscure-cards-button]")
+        .children()
+        .first()
+        .should("have.attr", "data-checked", "true");
+
+      cy.get("[data-name=obscure-cards-button]").click();
+      cy.get("[data-name=obscure-cards-button]")
+        .children()
+        .first()
+        .should("have.attr", "data-checked", "false");
+      cy.get("[data-name=menu-button]").click();
+    });
+
+    it("still sees own card content when obscure cards is enabled", () => {
+      setObscureCards(true);
+      cy.get("[data-name=card]:visible")
+        .first()
+        .find("[data-name=card-content]")
+        .should("contain", "Owner card text");
+      cy.get("[data-name=card]:visible")
+        .first()
+        .find("[data-name=obscured-placeholder]")
+        .should("not.exist");
+    });
+
+    it("can still edit own card when obscure cards is enabled", () => {
+      cy.get("[data-name=card-content]:visible").first().click();
+      cy.get("[data-name=card-edit-field]").should("exist");
+      cy.get("[data-name=card-edit-field]").type("{esc}");
+    });
+  });
+
+  context("as participant when obscure cards is enabled", () => {
+    before(() => {
+      setObscureCards(true);
+
+      cy.login("participant");
+      cy.visit(boardUrl);
+      cy.get("[data-name=rank]:visible")
+        .first()
+        .find("[data-name=card-text-input]")
+        .type("Participant card text");
+      cy.get("[data-name=rank]:visible")
+        .first()
+        .find("[data-name=card-author-input]")
+        .type("Participant{enter}");
+      cy.get("[data-name=card]:visible").should("have.length.at.least", 2);
+    });
+
+    beforeEach(() => {
+      cy.login("participant");
+      cy.visit(boardUrl);
+      cy.get("[data-name=card]:visible").should("have.length.at.least", 2);
+    });
+
+    it("does not see the content of cards created by others", () => {
+      cy.get("[data-name=card]:visible").each(($card) => {
+        const isOwn =
+          $card.find("[data-name=obscured-placeholder]").length === 0;
+        if (!isOwn) {
+          cy.wrap($card)
+            .find("[data-name=card-content]")
+            .should("not.contain", "Owner card text");
+          cy.wrap($card)
+            .find("[data-name=obscured-placeholder]")
+            .should("exist");
+        }
+      });
+    });
+
+    it("sees own card content unobscured", () => {
+      cy.get("[data-name=card]:visible")
+        .filter(":not(:has([data-name=obscured-placeholder]))")
+        .find("[data-name=card-content]")
+        .should("contain", "Participant card text");
+    });
+
+    it("cannot click to edit an obscured card", () => {
+      cy.get("[data-name=card]:visible")
+        .filter(":has([data-name=obscured-placeholder])")
+        .first()
+        .find("[data-name=card-content]")
+        .click();
+      cy.get("[data-name=card-edit-field]").should("not.exist");
+    });
+
+    it("has the obscure cards toggle disabled", () => {
+      cy.get("[data-name=menu-button]").click();
+      cy.get("[data-name=obscure-cards-button]").should(
+        "have.class",
+        "disabled",
+      );
+      cy.get("[data-name=menu-button]").click();
+    });
+  });
+
+  context("as participant when obscure cards is disabled", () => {
+    beforeEach(() => {
+      setObscureCards(false);
+      cy.login("participant");
+      cy.visit(boardUrl);
+      cy.get("[data-name=card]:visible").should("have.length.at.least", 2);
+    });
+
+    it("sees all card content", () => {
+      cy.get("[data-name=card]:visible")
+        .find("[data-name=obscured-placeholder]")
+        .should("not.exist");
+      cy.get("[data-name=card-content]:visible").should(
+        "contain",
+        "Owner card text",
+      );
+    });
+  });
+
+  after(() => {
+    cy.login("owner");
+    cy.intercept("boards").as("getBoards");
+    cy.visit("/");
+    cy.wait("@getBoards");
+    cy.get("[data-name=board-list-button]").click();
+    cy.get("[data-name=delete-button]").each(($el) => {
+      cy.wrap($el).click();
+      cy.get("[data-name=delete-confirm-button]").click();
+    });
+    cy.get("[data-name=board-table]").should("not.exist");
+  });
+});

--- a/cypress/e2e/ObscureCards.cy.js
+++ b/cypress/e2e/ObscureCards.cy.js
@@ -148,6 +148,7 @@ context("ObscureCards", () => {
     it("cannot click to edit an obscured card", () => {
       cy.get("[data-name=card]:visible")
         .filter(":has([data-name=obscured-placeholder])")
+        .should("have.length.at.least", 1)
         .first()
         .find("[data-name=card-content]")
         .click();

--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -26,6 +26,8 @@
   export let card;
   export let color;
 
+  $: obscured = $board.data?.obscure_cards && !card.owner;
+
   let editMode = false;
   let reactDrawOpen = false;
   let newCardText = "";
@@ -136,7 +138,11 @@
           <div class="m-0 w-100">
             <div class="d-flex flex-wrap">
               <div class="flex-grow-1">
-                {#if card.author.length > 0}
+                {#if obscured}
+                  <div class="text-secondary fw-bold">
+                    {$_("card.anonymous")}
+                  </div>
+                {:else if card.author.length > 0}
                   <div class:text-primary={!$darkMode} class="fw-bold pb-1">
                     <EncryptedText bind:text={card.author} />
                   </div>
@@ -191,9 +197,13 @@
             role="button"
             tabindex="0"
             on:keypress={null}
-            on:click={startEdit}
+            on:click={obscured ? null : startEdit}
           >
-            <EncryptedText bind:text={card.text} />
+            {#if obscured}
+              <div data-name="obscured-placeholder" class="obscured-text"></div>
+            {:else}
+              <EncryptedText bind:text={card.text} />
+            {/if}
           </div>
         </div>
       {/if}
@@ -279,5 +289,13 @@
 
   .pointer {
     cursor: pointer;
+  }
+
+  .obscured-text {
+    width: 100%;
+    height: 1em;
+    border-radius: 3px;
+    background: currentColor;
+    opacity: 0.15;
   }
 </style>

--- a/src/components/Menu.svelte
+++ b/src/components/Menu.svelte
@@ -145,6 +145,22 @@
         bind:checked={$board.voting_open}
       />
     </DropdownItem>
+    <DropdownItem
+      data-name="obscure-cards-button"
+      toggle={false}
+      disabled={!$board.owner && !$board.open_permission}
+      on:click={() =>
+        ($board = {
+          ...$board,
+          data: { ...$board.data, obscure_cards: !$board.data.obscure_cards },
+        })}
+    >
+      <ReadonlyCheckbox
+        label={$_("board.options.obscure_cards")}
+        checked={!!$board.data?.obscure_cards}
+        on:click={preventDefault}
+      />
+    </DropdownItem>
     {#if $board.owner}
       <DropdownItem
         data-name="anyone-is-owner-button"

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -55,6 +55,7 @@
   "board.options.download_csv": "CSV herunterladen",
   "board.options.copy_link": "Link kopieren",
   "board.options.new_column": "Neue Spalte",
+  "board.options.obscure_cards": "Karten verbergen",
   "board.options.open_permission": "Alle sind Admin",
   "board.delete": "Board löschen",
   "board.unlock": "Entsperren",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -57,6 +57,7 @@
   "board.options.copy_link": "Copy Link",
   "board.options.new_column": "New Column",
   "board.options.open_permission": "Everyone is Admin",
+  "board.options.obscure_cards": "Obscure Cards",
   "board.unlock": "Unlock",
   "board.author": "Author",
   "board.delete": "Delete board",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -55,6 +55,7 @@
   "board.options.download_csv": "Descargar CSV",
   "board.options.copy_link": "Copiar Enlace",
   "board.options.new_column": "Nueva Columna",
+  "board.options.obscure_cards": "Ocultar tarjetas",
   "board.options.open_permission": "Todos son administradores",
   "board.delete": "Eliminar tablero",
   "board.unlock": "Desbloquear",

--- a/src/lang/ko.json
+++ b/src/lang/ko.json
@@ -55,6 +55,7 @@
   "board.options.download_csv": "CSV 다운로드",
   "board.options.copy_link": "링크 복사하기",
   "board.options.new_column": "새로운 컬럼이",
+  "board.options.obscure_cards": "카드 가리기",
   "board.options.open_permission": "모두 관리자",
   "board.delete": "회고록 삭제",
   "board.unlock": "해제하기",

--- a/src/lang/pt_BR.json
+++ b/src/lang/pt_BR.json
@@ -56,6 +56,7 @@
   "board.options.download_csv": "Baixar CSV",
   "board.options.copy_link": "Copiar Link",
   "board.options.new_column": "Nova Coluna",
+  "board.options.obscure_cards": "Ocultar cartões",
   "board.options.open_permission": "Todos são administradores",
   "board.delete": "Apagar quadro",
   "board.unlock": "Desbloquear",

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -56,6 +56,7 @@
   "board.options.download_csv": "Скачать CSV",
   "board.options.copy_link": "Копировать ссылку на доску",
   "board.options.new_column": "Новая столбец",
+  "board.options.obscure_cards": "Скрыть карточки",
   "board.options.open_permission": "Все — администраторы",
   "board.delete": "Удалить доску",
   "board.unlock": "Разблокировать",

--- a/src/lang/tr.json
+++ b/src/lang/tr.json
@@ -56,6 +56,7 @@
   "board.options.download_csv": "CSV olarak indir",
   "board.options.copy_link": "Linki kopyala",
   "board.options.new_column": "Yeni sütün ekle",
+  "board.options.obscure_cards": "Kartları gizle",
   "board.options.open_permission": "Herkes Yönetici",
   "board.unlock": "Kilidi kaldır",
   "board.author": "Yazar",

--- a/src/lang/uk.json
+++ b/src/lang/uk.json
@@ -56,6 +56,7 @@
   "board.options.download_csv": "Завантажити CSV",
   "board.options.copy_link": "Скопіювати посилання",
   "board.options.new_column": "Новий стовпець",
+  "board.options.obscure_cards": "Приховати картки",
   "board.options.open_permission": "Всі — адміністратори",
   "board.unlock": "Розблокувати",
   "board.author": "Автор",

--- a/src/store.js
+++ b/src/store.js
@@ -40,6 +40,7 @@ export const board = writable({
   open_permission: false,
   data: {
     encryptionTest: "encryptionTest",
+    obscure_cards: false,
   },
 });
 


### PR DESCRIPTION
## Summary

- Adds an **Obscure Cards** toggle to the board menu (independent of the existing Voting toggle), as discussed in #175 option 2
- When enabled, participants see a redacted placeholder instead of card text/author for cards they didn't create
- Card authors always see their own cards unobscured; clicking to edit is blocked on obscured cards
- State stored in the existing `board.data` blob — no backend changes required
- Translated into all 8 supported languages

## Test plan

- [x] Toggle appears in menu for board owner and is disabled for regular participants
- [x] Defaults to off; persists across page reloads and syncs to other connected clients
- [x] Obscured cards show a full-width placeholder bar instead of text/author
- [x] Card owner always sees their own card content
- [x] Clicking an obscured card does not open edit mode
- [x] Disabling the toggle reveals all card content immediately
- [x] Cypress suite: `ObscureCards.cy.js` (10 tests) and updated `Menu.cy.js`

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)