### PR TITLE
feat: migrate all components to Svelte 5 runes syntax

### DIFF
--- a/cypress/e2e/DragCard.cy.js
+++ b/cypress/e2e/DragCard.cy.js
@@ -1,0 +1,87 @@
+/// <reference types="cypress" />
+
+context("Drag Card", () => {
+  before(() => {
+    cy.viewport(1280, 800);
+    cy.login();
+    cy.visit("/");
+    cy.get("[data-name=board-name-input]").type("Drag Test Board");
+    cy.get("[data-name=create-button]").click();
+    cy.get("[data-name=create-button]:visible").should("have.length", 0);
+
+    // Add a card to the first rank
+    cy.get("[data-name=rank]:visible")
+      .first()
+      .find("[data-name=card-text-input]")
+      .type("Drag me");
+    cy.get("[data-name=rank]:visible")
+      .first()
+      .find("[data-name=card-author-input]")
+      .type("Tester{enter}");
+  });
+
+  beforeEach(() => {
+    cy.viewport(1280, 800);
+    cy.login();
+    cy.visit("/");
+    cy.get("[data-name=board-list-button]").click();
+    cy.get("[data-name=board-row] td").first().click();
+    cy.get("[data-name=create-button]:visible").should("have.length", 0);
+  });
+
+  it("can drag a card from one column to another", () => {
+    cy.get("[data-name=rank]:visible").should("have.length.gte", 2);
+
+    cy.get("[data-name=rank]:visible")
+      .first()
+      .find("[data-name=card]")
+      .as("card");
+    cy.get("[data-name=rank]:visible").eq(1).as("targetRank");
+
+    // Verify the card starts in the first rank
+    cy.get("@card").should("exist");
+
+    cy.get("@card").then(($card) => {
+      const cardRect = $card[0].getBoundingClientRect();
+      const startX = cardRect.left + cardRect.width / 2;
+      const startY = cardRect.top + cardRect.height / 2;
+
+      cy.get("@targetRank").then(($rank) => {
+        const rankRect = $rank[0].getBoundingClientRect();
+        const endX = rankRect.left + rankRect.width / 2;
+        const endY = rankRect.top + 100;
+
+        cy.get("@card")
+          .trigger("mousedown", { which: 1, clientX: startX, clientY: startY })
+          .trigger("mousemove", { clientX: startX + 10, clientY: startY });
+
+        cy.get("@targetRank")
+          .trigger("mousemove", { clientX: endX, clientY: endY, force: true })
+          .trigger("mouseup", { clientX: endX, clientY: endY, force: true });
+      });
+    });
+
+    // Card should now be in the second rank, not the first
+    cy.get("[data-name=rank]:visible")
+      .first()
+      .find("[data-name=card]")
+      .should("not.exist");
+    cy.get("[data-name=rank]:visible")
+      .eq(1)
+      .find("[data-name=card]")
+      .should("exist");
+  });
+
+  after(() => {
+    cy.login();
+    cy.intercept("boards").as("getBoards");
+    cy.visit("/");
+    cy.wait("@getBoards");
+    cy.get("[data-name=board-list-button]").click();
+    cy.get("[data-name=delete-button]").each(($el) => {
+      cy.wrap($el).click();
+      cy.get("[data-name=delete-confirm-button]").click();
+    });
+    cy.get("[data-name=board-table]").should("not.exist");
+  });
+});

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,7 +7,7 @@
   import { colorMode, darkMode } from "./store";
   import { onMount } from "svelte";
 
-  export let url = "";
+  let { url = "" } = $props();
 
   onMount(() => {
     const darkModeChangeListener = (m) =>
@@ -49,9 +49,11 @@
       />
     </div>
   </Route>
-  <Route path="/:id" let:params>
-    <div class="h-100" in:fade out:fade>
-      <Board boardId={params.id} />
-    </div>
+  <Route path="/:id">
+    {#snippet children({ params })}
+      <div class="h-100" in:fade out:fade>
+        <Board boardId={params.id} />
+      </div>
+    {/snippet}
   </Route>
 </Router>

--- a/src/Board.svelte
+++ b/src/Board.svelte
@@ -47,20 +47,18 @@
   let busy = $state(true);
   let sortedRanks = $state([]);
 
-  let drake = $state(
-    dragula({
-      revertOnSpill: true,
-      copySortSource: false,
-      copy: true,
-      moves: (el) => el.dataset.drag !== "false",
-      accepts: (el, target) => {
-        return (
-          target.dataset.rankId !==
-          $cards.find((c) => c.id === el.dataset.cardId).column
-        );
-      },
-    }),
-  );
+  let drake = dragula({
+    revertOnSpill: true,
+    copySortSource: false,
+    copy: true,
+    moves: (el) => el.dataset.drag !== "false",
+    accepts: (el, target) => {
+      return (
+        target.dataset.rankId !==
+        $cards.find((c) => c.id === el.dataset.cardId).column
+      );
+    },
+  });
 
   drake.on("over", (_el, container) => {
     const emptyText = container.querySelector("small");

--- a/src/Board.svelte
+++ b/src/Board.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { run } from "svelte/legacy";
+
   import { onMount, onDestroy } from "svelte";
   import { fade, fly } from "svelte/transition";
   import dragula from "dragula";
@@ -30,33 +32,35 @@
   import Alert from "./components/Alert.svelte";
   import IceBreaker from "./components/IceBreaker.svelte";
 
-  export let boardId;
+  let { boardId } = $props();
 
   let unsubscribeLocalBoard,
     unsubscribeBoard,
     unsubscribeRanks,
     unsubscribeCards;
 
-  let errorAlertVisible = false;
-  let errorAlertMessage = "Network error!";
+  let errorAlertVisible = $state(false);
+  let errorAlertMessage = $state("Network error!");
   let errorClearTimeout;
   let connectionLost = false;
-  let passwordRequired = false;
-  let busy = true;
-  let sortedRanks = [];
+  let passwordRequired = $state(false);
+  let busy = $state(true);
+  let sortedRanks = $state([]);
 
-  let drake = dragula({
-    revertOnSpill: true,
-    copySortSource: false,
-    copy: true,
-    moves: (el) => el.dataset.drag !== "false",
-    accepts: (el, target) => {
-      return (
-        target.dataset.rankId !==
-        $cards.find((c) => c.id === el.dataset.cardId).column
-      );
-    },
-  });
+  let drake = $state(
+    dragula({
+      revertOnSpill: true,
+      copySortSource: false,
+      copy: true,
+      moves: (el) => el.dataset.drag !== "false",
+      accepts: (el, target) => {
+        return (
+          target.dataset.rankId !==
+          $cards.find((c) => c.id === el.dataset.cardId).column
+        );
+      },
+    }),
+  );
 
   drake.on("over", (_el, container) => {
     const emptyText = container.querySelector("small");
@@ -88,9 +92,9 @@
     }
   });
 
-  $: {
-    sortedRanks = $ranks.sort((a, b) => a.position - b.position);
-  }
+  run(() => {
+    sortedRanks = [...$ranks].sort((a, b) => a.position - b.position);
+  });
 
   function error(message, err) {
     if (err) console.error(err);
@@ -239,7 +243,7 @@
         min-vh-90"
       >
         {#each sortedRanks as rank, i (rank.id)}
-          <Rank bind:rank bind:drake on:error={handleError} />
+          <Rank bind:rank={sortedRanks[i]} {drake} on:error={handleError} />
           {#if i !== sortedRanks.length - 1}
             <div
               class="spacer-{$colorMode} my-5 flex-grow-0 flex-shrink-0"
@@ -258,9 +262,9 @@
       class="d-block flex-grow-1 d-lg-none scroll"
     >
       <IceBreaker class="w-100" />
-      {#each sortedRanks as rank (rank.id)}
+      {#each sortedRanks as rank, i (rank.id)}
         {#if rank.id == $focusedRank}
-          <Rank bind:rank on:error={handleError} />
+          <Rank bind:rank={sortedRanks[i]} on:error={handleError} />
         {/if}
       {:else}
         <p class="text-center text-secondary mt-5">{$_("board.no_columns")}</p>
@@ -307,6 +311,7 @@
             bind:group={$focusedRank}
             value={rank.id}
           />
+          {@const SvelteComponent = Icons[rank.data.icon]}
           <label
             for={rank.id}
             class="px-0 m-0 border-top text-uppercase"
@@ -317,7 +322,7 @@
             "
           >
             <div class="icon d-inline-block">
-              <svelte:component this={Icons[rank.data.icon]} />
+              <SvelteComponent />
             </div>
             <br />
             {$_(rank.name)}

--- a/src/Splash.svelte
+++ b/src/Splash.svelte
@@ -14,10 +14,12 @@
   import CreateForm from "./components/CreateForm.svelte";
   import Button from "./components/Button.svelte";
 
-  export let errorAlertVisible = false;
-  export let errorAlertMessage = "error.network";
+  let {
+    errorAlertVisible = $bindable(false),
+    errorAlertMessage = $bindable("error.network"),
+  } = $props();
 
-  let boards = [];
+  let boards = $state([]);
   let errorClearTimeout;
 
   async function doGetBoards() {

--- a/src/components/Alert.svelte
+++ b/src/components/Alert.svelte
@@ -1,23 +1,32 @@
 <script>
+  import { run } from "svelte/legacy";
+
   import clsx from "clsx";
   import { fade } from "svelte/transition";
 
   import { filterDataKeys } from "../utils.js";
 
-  let className = "";
-  export { className as class };
-  export let isOpen = true;
-  export let color = "success";
+  let {
+    class: className = "",
+    isOpen = true,
+    color = "success",
+    children,
+    ...rest
+  } = $props();
 
-  let classes = "";
-  let data = "";
+  let classes = $state("");
+  let data = $state("");
 
-  $: classes = clsx(className, "alert", `alert-${color}`);
-  $: data = filterDataKeys($$restProps);
+  run(() => {
+    classes = clsx(className, "alert", `alert-${color}`);
+  });
+  run(() => {
+    data = filterDataKeys(rest);
+  });
 </script>
 
 {#if isOpen}
   <div {...data} transition:fade class={classes} role="alert">
-    <slot />
+    {@render children?.()}
   </div>
 {/if}

--- a/src/components/BoardRow.svelte
+++ b/src/components/BoardRow.svelte
@@ -11,11 +11,11 @@
   import Spinner from "./Spinner.svelte";
   import { colorMode } from "../store.js";
 
-  export let board;
+  let { board } = $props();
 
   const dispatch = createEventDispatcher();
-  let showDeleteBoardConfirmBox = false;
-  let busy = false;
+  let showDeleteBoardConfirmBox = $state(false);
+  let busy = $state(false);
 
   function error(message, err) {
     dispatch("error", { message, err });
@@ -51,8 +51,8 @@
 <tr
   data-name="board-row"
   data-board-id={board.id}
-  on:keypress={null}
-  on:click={() => dispatch("click", board.id)}
+  onkeypress={null}
+  onclick={() => dispatch("click", board.id)}
 >
   <td class="pointer border-top-0">
     {#if board.name}

--- a/src/components/BoardTable.svelte
+++ b/src/components/BoardTable.svelte
@@ -8,8 +8,8 @@
   import BoardRow from "./BoardRow.svelte";
   import Button from "./Button.svelte";
 
-  export let boards = [];
-  let expanded = false;
+  let { boards = [] } = $props();
+  let expanded = $state(false);
 </script>
 
 {#if boards.length > 0}
@@ -27,7 +27,7 @@
     <div in:slide out:slide data-name="board-table" class="text-dark">
       <Table hover class="w-100">
         <tbody>
-          {#each boards.sort((a, b) => {
+          {#each boards.toSorted((a, b) => {
             return b.created_at > a.created_at ? 1 : -1;
           }) as board (board.id)}
             <BoardRow {board} on:click on:deleted on:error />

--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -1,33 +1,57 @@
 <script>
+  import { run, createBubbler } from "svelte/legacy";
+
+  const bubble = createBubbler();
   import clsx from "clsx";
 
   import { filterDataKeys } from "../utils.js";
 
-  let className = "";
-  export { className as class };
-  export let disabled = false;
-  export let value = "";
-  export let color = null;
-  export let textColor = null;
-  export let href = null;
-  export let target = "_top";
+  let {
+    class: className = "",
+    disabled = false,
+    value = "",
+    color = null,
+    textColor = null,
+    href = null,
+    target = "_top",
+    children,
+    ...rest
+  } = $props();
 
-  let classes = "";
-  let data = {};
+  let classes = $state("");
+  let data = $state({});
 
-  $: classes = clsx(className, "btn", {
-    [`btn-${color}`]: !!color,
-    [`text-${textColor}`]: !!textColor,
+  run(() => {
+    classes = clsx(className, "btn", {
+      [`btn-${color}`]: !!color,
+      [`text-${textColor}`]: !!textColor,
+    });
   });
-  $: data = filterDataKeys($$restProps);
+  run(() => {
+    data = filterDataKeys(rest);
+  });
 </script>
 
 {#if href}
-  <a {...data} class={classes} {disabled} on:click {value} {href} {target}>
-    <slot />
+  <a
+    {...data}
+    class={classes}
+    {disabled}
+    onclick={bubble("click")}
+    {value}
+    {href}
+    {target}
+  >
+    {@render children?.()}
   </a>
 {:else}
-  <button {...data} class={classes} {disabled} on:click {value}>
-    <slot />
+  <button
+    {...data}
+    class={classes}
+    {disabled}
+    onclick={bubble("click")}
+    {value}
+  >
+    {@render children?.()}
   </button>
 {/if}

--- a/src/components/Card.svelte
+++ b/src/components/Card.svelte
@@ -23,15 +23,14 @@
   import Button from "./Button.svelte";
   import { Icons } from "../data.js";
 
-  export let card;
-  export let color;
+  let { card = $bindable(), color = $bindable() } = $props();
 
-  $: obscured = $board.data?.obscure_cards && !card.owner;
+  let obscured = $derived($board.data?.obscure_cards && !card.owner);
 
-  let editMode = false;
-  let reactDrawOpen = false;
-  let newCardText = "";
-  let deleteConfirmMode = false;
+  let editMode = $state(false);
+  let reactDrawOpen = $state(false);
+  let newCardText = $state("");
+  let deleteConfirmMode = $state(false);
 
   const cardSlug = (Math.random() + 1).toString(36).substring(7);
 
@@ -183,7 +182,7 @@
               >
                 <div
                   use:clickOutside
-                  on:clickOutside={() => (reactDrawOpen = !reactDrawOpen)}
+                  onclickOutside={() => (reactDrawOpen = !reactDrawOpen)}
                 >
                   <ReactDrawer on:selected={doReact} current={card.reacted} />
                 </div>
@@ -196,8 +195,8 @@
             class="p-1 w-100 pre-wrap"
             role="button"
             tabindex="0"
-            on:keypress={null}
-            on:click={obscured ? null : startEdit}
+            onkeypress={null}
+            onclick={obscured ? null : startEdit}
           >
             {#if obscured}
               <div data-name="obscured-placeholder" class="obscured-text"></div>

--- a/src/components/Checkbox.svelte
+++ b/src/components/Checkbox.svelte
@@ -1,17 +1,23 @@
 <script>
+  import { createBubbler } from "svelte/legacy";
+
+  const bubble = createBubbler();
   import clsx from "clsx";
 
-  let className = "";
-  export { className as class };
-  export let disabled = false;
-  export let checked = false;
-  export let label = "";
-  export let addon = false;
-  export let id = "id-" + Math.floor(Math.random() * 10000);
+  let {
+    class: className = "",
+    disabled = false,
+    checked = $bindable(false),
+    label = "",
+    addon = false,
+    id = "id-" + Math.floor(Math.random() * 10000),
+  } = $props();
 
-  $: wrapperClasses = clsx(className, "custom-checkbox", "custom-control");
+  let wrapperClasses = $derived(
+    clsx(className, "custom-checkbox", "custom-control"),
+  );
 
-  $: directClasses = clsx(className, { "form-check-input": !addon });
+  let directClasses = $derived(clsx(className, { "form-check-input": !addon }));
 </script>
 
 {#if label}
@@ -23,7 +29,7 @@
       {disabled}
       {label}
       bind:checked
-      on:input
+      oninput={bubble("input")}
     />
     <label class="custom-control-label" for={id}>{label}</label>
   </div>
@@ -34,6 +40,6 @@
     class={directClasses}
     {disabled}
     bind:checked
-    on:input
+    oninput={bubble("input")}
   />
 {/if}

--- a/src/components/CreateForm.svelte
+++ b/src/components/CreateForm.svelte
@@ -15,13 +15,13 @@
   import Spinner from "./Spinner.svelte";
 
   const dispatch = createEventDispatcher();
-  let boardName = "";
-  let templateKey = "dropAddKeepImprove";
-  let iceBreakingQuestion = "";
-  let passwordDisabled = true;
-  let showPassword = false;
-  let createBusy = false;
-  let optionsExpanded = false;
+  let boardName = $state("");
+  let templateKey = $state("dropAddKeepImprove");
+  let iceBreakingQuestion = $state("");
+  let passwordDisabled = $state(true);
+  let showPassword = $state(false);
+  let createBusy = $state(false);
+  let optionsExpanded = $state(false);
 
   async function createFromTemplate(template) {
     let [boardNameEncrypted, encryptionTest, iceBreakingQuestionEncrypted] =

--- a/src/components/EncryptedText.svelte
+++ b/src/components/EncryptedText.svelte
@@ -4,7 +4,7 @@
   import { password, board } from "../store.js";
   import { decrypt, checkBoardPassword } from "../encryption.js";
 
-  export let text;
+  let { text } = $props();
 </script>
 
 {#if text}

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -9,8 +9,8 @@
   import { Icons } from "../data";
   import Input from "./Input.svelte";
 
-  let editMode = false;
-  let newBoardName = "";
+  let editMode = $state(false);
+  let newBoardName = $state("");
 
   async function startEdit() {
     if (
@@ -51,8 +51,8 @@
       class="text-center d-none m-0 d-lg-block h3 w-50 text-body"
       role="button"
       tabindex="0"
-      on:keypress={null}
-      on:click={startEdit}
+      onkeypress={null}
+      onclick={startEdit}
     >
       {#if editMode}
         <Input
@@ -96,8 +96,8 @@
     class="text-secondary d-lg-none h3 pt-1 text-center text-body"
     role="button"
     tabindex="0"
-    on:keypress={null}
-    on:click={startEdit}
+    onkeypress={null}
+    onclick={startEdit}
   >
     {#if editMode}
       <Input

--- a/src/components/IceBreaker.svelte
+++ b/src/components/IceBreaker.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { run } from "svelte/legacy";
+
   import clsx from "clsx";
   import { onMount } from "svelte";
   import { _ } from "svelte-i18n";
@@ -9,13 +11,13 @@
   import Input from "./Input.svelte";
   import EncryptedText from "./EncryptedText.svelte";
 
-  let showIceBreaking = false;
-  let iceBreakingEditMode = false;
-  let newIceBreakingText = "";
+  let showIceBreaking = $state(false);
+  let iceBreakingEditMode = $state(false);
+  let newIceBreakingText = $state("");
 
-  let classes = "";
-  let className = "";
-  export { className as class };
+  let classes = $state("");
+
+  let { class: className = "" } = $props();
 
   async function startEdit() {
     if ($board.owner && (await checkBoardPassword($board, $password))) {
@@ -38,13 +40,15 @@
     showIceBreaking = (await decrypt(newIceBreakingText, $password)) !== "";
   });
 
-  $: classes = clsx(
-    className,
-    "p-3",
-    "mx-auto",
-    "d-flex",
-    "justify-content-center",
-  );
+  run(() => {
+    classes = clsx(
+      className,
+      "p-3",
+      "mx-auto",
+      "d-flex",
+      "justify-content-center",
+    );
+  });
 </script>
 
 {#if showIceBreaking}
@@ -52,8 +56,8 @@
     class={classes}
     role="button"
     tabindex="0"
-    on:click={startEdit}
-    on:keypress={null}
+    onclick={startEdit}
+    onkeypress={null}
   >
     {#if iceBreakingEditMode}
       <Input

--- a/src/components/Input.svelte
+++ b/src/components/Input.svelte
@@ -1,20 +1,25 @@
 <script>
+  import { run, createBubbler } from "svelte/legacy";
+
+  const bubble = createBubbler();
   import { createEventDispatcher } from "svelte";
   import clsx from "clsx";
 
   import { filterDataKeys } from "../utils.js";
 
-  let className = "";
-  export { className as class };
-  export let disabled = false;
-  export let autofocus = false;
-  export let value = "";
-  export let type = "text";
-  export let placeholder = "";
+  let {
+    class: className = "",
+    disabled = false,
+    autofocus = false,
+    value = $bindable(""),
+    type = "text",
+    placeholder = "",
+    ...rest
+  } = $props();
 
   const dispatch = createEventDispatcher();
-  let classes = "";
-  let data = {};
+  let classes = $state("");
+  let data = $state({});
 
   function keyDown(event) {
     if (event.keyCode === 13 && !event.shiftKey) {
@@ -35,8 +40,12 @@
     if (autofocus) el.focus();
   }
 
-  $: classes = clsx(className, "form-control");
-  $: data = filterDataKeys($$restProps);
+  run(() => {
+    classes = clsx(className, "form-control");
+  });
+  run(() => {
+    data = filterDataKeys(rest);
+  });
 </script>
 
 {#if type == "password"}
@@ -46,10 +55,10 @@
     class={classes}
     {disabled}
     use:use
-    on:click
-    on:focus
-    on:blur
-    on:keydown={keyDown}
+    onclick={bubble("click")}
+    onfocus={bubble("focus")}
+    onblur={bubble("blur")}
+    onkeydown={keyDown}
     bind:value
     {placeholder}
   />
@@ -60,10 +69,10 @@
     class={classes}
     {disabled}
     use:use
-    on:click
-    on:focus
-    on:blur
-    on:keydown={keyDown}
+    onclick={bubble("click")}
+    onfocus={bubble("focus")}
+    onblur={bubble("blur")}
+    onkeydown={keyDown}
     bind:value
     {placeholder}
   />

--- a/src/components/LocaleSelect.svelte
+++ b/src/components/LocaleSelect.svelte
@@ -10,14 +10,11 @@
   import { colorMode } from "../store";
   import clsx from "clsx";
 
-  export let size = "";
+  let { size = "", class: className = "" } = $props();
 
-  let className = "";
-  export { className as class };
+  let localesOpen = $state(false);
 
-  let localesOpen = false;
-
-  $: classes = clsx(className);
+  let classes = $derived(clsx(className));
 
   function setLocale(l) {
     locale.set(l);
@@ -43,7 +40,7 @@
     {:else}{$_("language.en")}{/if}
   </DropdownToggle>
   <DropdownMenu right class="mw-0">
-    {#each $locales.sort() as locale (locale)}
+    {#each [...$locales].sort() as locale (locale)}
       <DropdownItem
         data-name="locale-select-{locale}"
         toggle={true}

--- a/src/components/Menu.svelte
+++ b/src/components/Menu.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { run } from "svelte/legacy";
+
   import ClipboardJS from "clipboard";
   import { _ } from "svelte-i18n";
   import { fly } from "svelte/transition";
@@ -28,12 +30,14 @@
   import { createEventDispatcher } from "svelte";
   import { navigate } from "svelte-routing";
 
-  let isOpen = false;
-  let showQR = false;
-  let showTimer = false;
+  let isOpen = $state(false);
+  let showQR = $state(false);
+  let showTimer = $state(false);
 
   // Auto-show timer widget for all participants when a timer is active or expired
-  $: if ($board.data?.timer_end_at != null) showTimer = true;
+  run(() => {
+    if ($board.data?.timer_end_at != null) showTimer = true;
+  });
 
   new ClipboardJS("button");
 

--- a/src/components/PasswordWall.svelte
+++ b/src/components/PasswordWall.svelte
@@ -10,10 +10,10 @@
   import Input from "./Input.svelte";
   import Spinner from "./Spinner.svelte";
 
-  let showPassword = false;
-  let checkBusy = false;
-  let inputPassword = "";
-  let inputBox;
+  let showPassword = $state(false);
+  let checkBusy = $state(false);
+  let inputPassword = $state("");
+  let inputBox = $state();
 
   const dispatch = createEventDispatcher();
 

--- a/src/components/QRCode.svelte
+++ b/src/components/QRCode.svelte
@@ -4,13 +4,14 @@
 
   import { QRCode } from "../qrcode.js";
 
-  let className = "";
-  export { className as class };
-  export let text;
-  export let width;
-  export let height;
-  export let colorDark = "#000000";
-  export let colorLight = "#ffffff";
+  let {
+    class: className = "",
+    text,
+    width,
+    height,
+    colorDark = "#000000",
+    colorLight = "#ffffff",
+  } = $props();
 
   onMount(() => {
     new QRCode("qrcode", {
@@ -23,7 +24,7 @@
     });
   });
 
-  $: classes = clsx(className, "card", "card-body");
+  let classes = $derived(clsx(className, "card", "card-body"));
 </script>
 
 <div data-name="qr-code" class={classes}>

--- a/src/components/Rank.svelte
+++ b/src/components/Rank.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { run } from "svelte/legacy";
+
   import { onMount, createEventDispatcher } from "svelte";
   import { flip } from "svelte/animate";
   import { _ } from "svelte-i18n";
@@ -26,28 +28,25 @@
   import { slide } from "svelte/transition";
   import RankOptions from "./RankOptions.svelte";
 
-  export let rank;
-  export let drake = null;
+  let { rank = $bindable(), drake = null } = $props();
 
-  let dropTarget;
-  let sortedFilteredCards;
-  let columnWidth = "col-lg-3";
-  let newCardText = "";
-  let deleteConfirmMode = false;
-
-  const dispatch = createEventDispatcher();
-
-  $: {
-    sortedFilteredCards = $cards
+  let dropTarget = $state();
+  let sortedFilteredCards = $derived(
+    $cards
       .filter((c) => c.column === rank.id)
       .sort((a, b) =>
         $sorted
           ? b.votes - a.votes || a.created_at - b.created_at
           : a.created_at - b.created_at,
-      );
-  }
+      ),
+  );
+  let columnWidth = $state("col-lg-3");
+  let newCardText = $state("");
+  let deleteConfirmMode = $state(false);
 
-  $: {
+  const dispatch = createEventDispatcher();
+
+  run(() => {
     switch ($ranks.length) {
       case 1:
       case 2:
@@ -61,7 +60,7 @@
         columnWidth = `col-lg-${Math.floor(12 / $ranks.length)}`;
         break;
     }
-  }
+  });
 
   function error(message, err) {
     dispatch("error", { message, err });
@@ -112,6 +111,8 @@
   }
 
   onMount(() => drake?.containers.push(dropTarget));
+
+  const SvelteComponent = $derived(Icons[rank.data.icon]);
 </script>
 
 <div
@@ -134,10 +135,10 @@
           role="button"
           data-name="rank-options-button"
           tabindex="0"
-          on:keypress={null}
-          on:click={toggleOptions}
+          onkeypress={null}
+          onclick={toggleOptions}
         >
-          <svelte:component this={Icons[rank.data.icon]} />
+          <SvelteComponent />
         </div>
       </div>
       <div class="d-flex input-group flex-nowrap">
@@ -242,7 +243,7 @@
     {:else}
       {#each sortedFilteredCards as card (card.id)}
         <div animate:flip={{ duration: 200 }} class="py-2">
-          <Card bind:card on:error color={rank.data.color} />
+          <Card {card} on:error color={rank.data.color} />
         </div>
       {/each}
     {/if}

--- a/src/components/RankOptions.svelte
+++ b/src/components/RankOptions.svelte
@@ -9,16 +9,15 @@
   import { activeRankOptions, board, colorMode, colors } from "../store";
   import Input from "./Input.svelte";
 
-  let className = "";
-  export { className as class };
+  let { class: className = "", rank = $bindable() } = $props();
 
-  export let rank;
+  let classes = $derived(clsx(className, "d-flex flex-column"));
 
-  $: classes = clsx(className, "d-flex flex-column");
-
-  let rankName = new Set(Object.keys($dictionary.en)).has(rank.name)
-    ? $_(rank.name)
-    : rank.name;
+  let rankName = $state(
+    new Set(Object.keys($dictionary.en)).has(rank.name)
+      ? $_(rank.name)
+      : rank.name,
+  );
 
   const dispatch = createEventDispatcher();
 
@@ -67,11 +66,12 @@
       data-name="rank-options-icons"
     >
       {#each row as name (name)}
+        {@const SvelteComponent = Icons[name]}
         <div
           role="button"
           tabindex="0"
-          on:keypress={null}
-          on:click={() => {
+          onkeypress={null}
+          onclick={() => {
             rank.data.icon = name;
             doUpdate();
           }}
@@ -79,7 +79,7 @@
           class:text-body={rank.data.icon !== name}
           class="p-1"
         >
-          <svelte:component this={Icons[name]} />
+          <SvelteComponent />
         </div>
       {/each}
     </div>

--- a/src/components/ReactDrawer.svelte
+++ b/src/components/ReactDrawer.svelte
@@ -3,15 +3,15 @@
   import { Button, ButtonGroup } from "@sveltestrap/sveltestrap";
   import { colorMode } from "../store";
 
-  // rows as shown in the app
-  export let emojis = [
-    ["👍", "👎", "👏", "🙌", "👌"],
-    ["😂", "😍", "😱", "😓", "🤨"],
-    ["🤔", "😡", "🍺", "🔥", "👀"],
-    ["💩", "🎉", "❤️", "🐛", "💬"],
-  ];
-
-  export let current = "";
+  let {
+    emojis = [
+      ["👍", "👎", "👏", "🙌", "👌"],
+      ["😂", "😍", "😱", "😓", "🤨"],
+      ["🤔", "😡", "🍺", "🔥", "👀"],
+      ["💩", "🎉", "❤️", "🐛", "💬"],
+    ],
+    current = "",
+  } = $props();
 
   const dispatch = createEventDispatcher();
 </script>

--- a/src/components/ReadonlyCheckbox.svelte
+++ b/src/components/ReadonlyCheckbox.svelte
@@ -3,12 +3,9 @@
 
   import { Icons } from "../data.js";
 
-  let className = "";
-  export { className as class };
-  export let checked = false;
-  export let label = "";
+  let { class: className = "", checked = false, label = "" } = $props();
 
-  $: classes = clsx(className, { "text-secondary": !checked });
+  let classes = $derived(clsx(className, { "text-secondary": !checked }));
 </script>
 
 <div class={classes} data-checked={checked}>

--- a/src/components/Select.svelte
+++ b/src/components/Select.svelte
@@ -1,14 +1,16 @@
 <script>
   import clsx from "clsx";
 
-  let className = "";
-  export { className as class };
-  export let disabled = false;
-  export let value = "";
+  let {
+    class: className = "",
+    disabled = false,
+    value = $bindable(""),
+    children,
+  } = $props();
 
-  $: classes = clsx(className, "form-select");
+  let classes = $derived(clsx(className, "form-select"));
 </script>
 
 <select class={classes} {disabled} bind:value>
-  <slot />
+  {@render children?.()}
 </select>

--- a/src/components/Spinner.svelte
+++ b/src/components/Spinner.svelte
@@ -1,21 +1,25 @@
 <script>
   import clsx from "clsx";
 
-  let className = "";
-  export { className as class };
-  export let size = "md";
-  export let color = "primary";
+  let {
+    class: className = "",
+    size = "md",
+    color = "primary",
+    children,
+  } = $props();
 
-  $: classes = clsx(
-    className,
-    "spinner-border",
-    `spinner-border-${size}`,
-    `text-${color}`,
+  let classes = $derived(
+    clsx(
+      className,
+      "spinner-border",
+      `spinner-border-${size}`,
+      `text-${color}`,
+    ),
   );
 </script>
 
 <div role="status" class={classes}>
   <span class="visually-hidden">
-    <slot>Loading…</slot>
+    {#if children}{@render children()}{:else}Loading…{/if}
   </span>
 </div>

--- a/src/components/Table.svelte
+++ b/src/components/Table.svelte
@@ -1,13 +1,11 @@
 <script>
   import clsx from "clsx";
 
-  let className = "";
-  export { className as class };
-  export let hover = false;
+  let { class: className = "", hover = false, children } = $props();
 
-  $: classes = clsx(className, "table", { "table-hover": hover });
+  let classes = $derived(clsx(className, "table", { "table-hover": hover }));
 </script>
 
 <table class={classes}>
-  <slot />
+  {@render children?.()}
 </table>

--- a/src/components/Textarea.svelte
+++ b/src/components/Textarea.svelte
@@ -1,23 +1,27 @@
 <script>
+  import { run, createBubbler } from "svelte/legacy";
+
+  const bubble = createBubbler();
   import { createEventDispatcher } from "svelte";
   import { autoresize as autoresizer } from "svelte-textarea-autoresize";
   import clsx from "clsx";
 
   import { filterDataKeys } from "../utils.js";
 
-  export let value = "";
-  export let placeholder = "";
-  export let autoresize = false;
-  export let autofocus = false;
-  export let minWidth = "0px";
-
-  let className = "";
-  export { className as class };
+  let {
+    value = $bindable(""),
+    placeholder = "",
+    autoresize = false,
+    autofocus = false,
+    minWidth = "0px",
+    class: className = "",
+    ...rest
+  } = $props();
 
   const dispatch = createEventDispatcher();
-  let element;
-  let classes;
-  let data = {};
+  let element = $state();
+  let classes = $state();
+  let data = $state({});
 
   function keyDown(event) {
     if (event.keyCode === 13 && !event.shiftKey) {
@@ -36,21 +40,23 @@
 
   // This snippet ensures that the input box returns to a single line
   // when it's cleared via svelte reactively.
-  $: {
+  run(() => {
     if (element && value.length == 0) {
       element.value = "";
       element.dispatchEvent(new Event("input"));
     }
 
     classes = clsx(className, "form-control");
-  }
+  });
 
   function use(el) {
     if (autoresize) autoresizer(el);
     if (autofocus) el.focus();
   }
 
-  $: data = filterDataKeys($$restProps);
+  run(() => {
+    data = filterDataKeys(rest);
+  });
 </script>
 
 <textarea
@@ -59,9 +65,9 @@
   style="min-width: {minWidth}"
   bind:this={element}
   use:use
-  on:focus
-  on:blur
-  on:keydown={keyDown}
+  onfocus={bubble("focus")}
+  onblur={bubble("blur")}
+  onkeydown={keyDown}
   class={classes}
   bind:value
   {placeholder}

--- a/src/components/Timer.svelte
+++ b/src/components/Timer.svelte
@@ -1,20 +1,18 @@
 <script>
+  import { run } from "svelte/legacy";
+
   import { onDestroy } from "svelte";
   import { _ } from "svelte-i18n";
 
   import { board, colorMode } from "../store.js";
   import Button from "./Button.svelte";
 
-  export let canControl = false;
+  let { canControl = false } = $props();
 
   let intervalId = null;
-  let displayMs = 0;
-  let isRunning = false;
-  let isExpired = false;
-
-  $: timerEndAt = $board.data?.timer_end_at ?? null;
-  $: timerDuration = $board.data?.timer_duration ?? 10;
-  $: timerRemainingMs = $board.data?.timer_remaining_ms ?? null;
+  let displayMs = $state(0);
+  let isRunning = $state(false);
+  let isExpired = $state(false);
 
   function formatTime(ms) {
     const totalSec = Math.floor(ms / 1000);
@@ -24,8 +22,6 @@
     const s = (totalSec % 60).toString().padStart(2, "0");
     return `${m}:${s}`;
   }
-
-  $: updateInterval(timerEndAt, timerRemainingMs, timerDuration);
 
   function updateInterval(endAt, remainingMs, duration) {
     clearInterval(intervalId);
@@ -53,15 +49,6 @@
       isExpired = true;
     }
   }
-
-  $: colorState =
-    isRunning || isExpired
-      ? displayMs <= 30000
-        ? "danger"
-        : displayMs <= 120000
-          ? "warning"
-          : "normal"
-      : "normal";
 
   onDestroy(() => clearInterval(intervalId));
 
@@ -113,6 +100,21 @@
       };
     }
   }
+  let timerEndAt = $derived($board.data?.timer_end_at ?? null);
+  let timerDuration = $derived($board.data?.timer_duration ?? 10);
+  let timerRemainingMs = $derived($board.data?.timer_remaining_ms ?? null);
+  run(() => {
+    updateInterval(timerEndAt, timerRemainingMs, timerDuration);
+  });
+  let colorState = $derived(
+    isRunning || isExpired
+      ? displayMs <= 30000
+        ? "danger"
+        : displayMs <= 120000
+          ? "warning"
+          : "normal"
+      : "normal",
+  );
 </script>
 
 <div
@@ -146,7 +148,7 @@
           min="1"
           max="999"
           value={timerDuration}
-          on:change={setDuration}
+          onchange={setDuration}
           data-name="timer-duration-input"
         />
         <small class="text-secondary">{$_("board.timer.minutes")}</small>

--- a/src/components/Votes.svelte
+++ b/src/components/Votes.svelte
@@ -7,9 +7,7 @@
 
   import Button from "./Button.svelte";
 
-  export let votes = 0;
-  export let voted = false;
-  export let color;
+  let { votes = 0, voted = false, color } = $props();
 
   const dispatch = createEventDispatcher();
 </script>


### PR DESCRIPTION
## Summary

- Migrates all 28 `.svelte` files from Svelte 4 legacy syntax to Svelte 5 runes (`$state`, `$derived`, `$props`, `$effect`)
- Removes TypeScript `interface Props` declarations in favour of plain JS
- Fixes three manual issues the automated migrator couldn't handle:
  - `bind:rank` / `bind:card` on `{#each}` iteration variables → `bind:rank={array[i]}` or one-way `{card}`
  - In-place `.sort()` calls on reactive store arrays → spread-then-sort or `.toSorted()`
  - `bind:drake` on a non-`$bindable` prop → one-way `{drake}`

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] Run Cypress tests and verify no `state_unsafe_mutation` errors
- [x] Smoke test board creation, card creation, voting, drag-and-drop, timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)