### PR TITLE
feat: add board template export and import as YAML

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 25.x
-      - uses: cypress-io/github-action@v5
+      - uses: cypress-io/github-action@v7
         with:
           build: npm run build -- --mode=development
           start: npm run preview

--- a/cypress/.gitignore
+++ b/cypress/.gitignore
@@ -1,4 +1,3 @@
 videos/
 screenshots/
-fixtures/
 downloads/

--- a/cypress/e2e/Template.cy.js
+++ b/cypress/e2e/Template.cy.js
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+import { load as loadYaml } from "js-yaml";
+
 context("Template", () => {
   before(() => {
     cy.login();
@@ -32,21 +34,17 @@ context("Template", () => {
 
     cy.readFile(
       "cypress/downloads/retro-tools-Template Test Board-template.yaml",
-    ).then((yaml) => {
-      expect(yaml).to.include("columns:");
-      // js-yaml serializes plain strings without quotes
-      expect(yaml).to.include("name: Drop");
-      expect(yaml).to.include("icon: delete");
-      expect(yaml).to.include("color: red");
-      expect(yaml).to.include("name: Improve");
-      // Built-in columns carry their i18n key
-      expect(yaml).to.include(
-        "key: board.template.drop_add_keep_improve.column.drop",
-      );
-      // Columns appear in position order (Drop first, Improve last)
-      expect(yaml.indexOf("name: Drop")).to.be.lessThan(
-        yaml.indexOf("name: Improve"),
-      );
+    ).then((text) => {
+      const doc = loadYaml(text);
+      expect(doc.columns).to.have.length(4);
+      // Columns appear in position order
+      expect(doc.columns[0]).to.include({
+        name: "Drop",
+        icon: "delete",
+        color: "red",
+        key: "board.template.drop_add_keep_improve.column.drop",
+      });
+      expect(doc.columns[3].name).to.eq("Improve");
     });
   });
 

--- a/cypress/e2e/Template.cy.js
+++ b/cypress/e2e/Template.cy.js
@@ -1,0 +1,92 @@
+/// <reference types="cypress" />
+
+context("Template", () => {
+  before(() => {
+    cy.login();
+    cy.visit("/");
+    cy.get("[data-name=board-name-input]").type("Template Test Board");
+    cy.get("[data-name=create-button]").click();
+    cy.get("[data-name=create-button]:visible").should("have.length", 0);
+  });
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit("/");
+    cy.get("[data-name=board-list-button]").click();
+    cy.get("[data-name=board-row] td").first().click();
+    cy.get("[data-name=create-button]:visible").should("have.length", 0);
+  });
+
+  it("shows the download template button in the menu", () => {
+    cy.get("[data-name=menu-button]").click();
+    cy.get("[data-name=download-template-button]").should("be.visible");
+    cy.get("[data-name=menu-button]").click();
+  });
+
+  it("downloads the board template as YAML with retro-tools prefix", () => {
+    cy.get("[data-name=menu-button]").click();
+    cy.get("[data-name=download-template-button]").click();
+
+    cy.readFile("cypress/downloads/retro-tools-Template Test Board-template.yaml").then(
+      (yaml) => {
+        expect(yaml).to.include("columns:");
+        expect(yaml).to.include('"Drop"');
+        expect(yaml).to.include("icon: delete");
+        expect(yaml).to.include("color: red");
+        expect(yaml).to.include('"Improve"');
+        // Columns appear in position order (Drop first, Improve last)
+        expect(yaml.indexOf('"Drop"')).to.be.lessThan(yaml.indexOf('"Improve"'));
+      },
+    );
+  });
+
+  it("can import a YAML template and create a board from it", () => {
+    cy.visit("/");
+    cy.get("[data-name=more-settings-button]").click();
+    cy.get('input[type="file"]').selectFile("cypress/fixtures/template.yaml", {
+      force: true,
+    });
+    cy.get("select").should("have.value", "custom");
+    cy.get("select option[value=custom]").should(
+      "have.text",
+      "Custom (imported)",
+    );
+
+    cy.get("[data-name=board-name-input]").type("Imported Board");
+    cy.get("[data-name=create-button]").click();
+    cy.get("[data-name=create-button]:visible").should("have.length", 0);
+
+    cy.get("[data-name=rank]:visible")
+      .first()
+      .find("[data-name=card-text-input]")
+      .should("have.attr", "placeholder", "Went well");
+  });
+
+  it("shows an error for an invalid template file", () => {
+    cy.visit("/");
+    cy.get("[data-name=more-settings-button]").click();
+    cy.get('input[type="file"]').selectFile(
+      { contents: Cypress.Buffer.from(""), fileName: "empty.yaml" },
+      { force: true },
+    );
+    cy.get("[data-name=error-alert]").should("be.visible");
+    cy.get("[data-name=error-alert]").should(
+      "have.text",
+      "Invalid template file",
+    );
+  });
+
+  after(() => {
+    cy.login();
+    cy.intercept("boards").as("getBoards");
+    cy.visit("/");
+    cy.wait("@getBoards");
+    cy.get("[data-name=board-list-button]").should("have.length", 1);
+    cy.get("[data-name=board-list-button]").click();
+    cy.get("[data-name=delete-button]").each(($el) => {
+      cy.wrap($el).click();
+      cy.get("[data-name=delete-confirm-button]").click();
+    });
+    cy.get("[data-name=board-table]").should("not.exist");
+  });
+});

--- a/cypress/e2e/Template.cy.js
+++ b/cypress/e2e/Template.cy.js
@@ -24,6 +24,9 @@ context("Template", () => {
   });
 
   it("downloads the board template as YAML with retro-tools prefix", () => {
+    // Wait for board data to fully load before downloading (board.name must be set)
+    cy.get("[data-name=rank]:visible").should("have.length.at.least", 1);
+
     cy.get("[data-name=menu-button]").click();
     cy.get("[data-name=download-template-button]").click();
 

--- a/cypress/e2e/Template.cy.js
+++ b/cypress/e2e/Template.cy.js
@@ -34,12 +34,19 @@ context("Template", () => {
       "cypress/downloads/retro-tools-Template Test Board-template.yaml",
     ).then((yaml) => {
       expect(yaml).to.include("columns:");
-      expect(yaml).to.include('"Drop"');
+      // js-yaml serializes plain strings without quotes
+      expect(yaml).to.include("name: Drop");
       expect(yaml).to.include("icon: delete");
       expect(yaml).to.include("color: red");
-      expect(yaml).to.include('"Improve"');
+      expect(yaml).to.include("name: Improve");
+      // Built-in columns carry their i18n key
+      expect(yaml).to.include(
+        "key: board.template.drop_add_keep_improve.column.drop",
+      );
       // Columns appear in position order (Drop first, Improve last)
-      expect(yaml.indexOf('"Drop"')).to.be.lessThan(yaml.indexOf('"Improve"'));
+      expect(yaml.indexOf("name: Drop")).to.be.lessThan(
+        yaml.indexOf("name: Improve"),
+      );
     });
   });
 

--- a/cypress/e2e/Template.cy.js
+++ b/cypress/e2e/Template.cy.js
@@ -30,17 +30,17 @@ context("Template", () => {
     cy.get("[data-name=menu-button]").click();
     cy.get("[data-name=download-template-button]").click();
 
-    cy.readFile("cypress/downloads/retro-tools-Template Test Board-template.yaml").then(
-      (yaml) => {
-        expect(yaml).to.include("columns:");
-        expect(yaml).to.include('"Drop"');
-        expect(yaml).to.include("icon: delete");
-        expect(yaml).to.include("color: red");
-        expect(yaml).to.include('"Improve"');
-        // Columns appear in position order (Drop first, Improve last)
-        expect(yaml.indexOf('"Drop"')).to.be.lessThan(yaml.indexOf('"Improve"'));
-      },
-    );
+    cy.readFile(
+      "cypress/downloads/retro-tools-Template Test Board-template.yaml",
+    ).then((yaml) => {
+      expect(yaml).to.include("columns:");
+      expect(yaml).to.include('"Drop"');
+      expect(yaml).to.include("icon: delete");
+      expect(yaml).to.include("color: red");
+      expect(yaml).to.include('"Improve"');
+      // Columns appear in position order (Drop first, Improve last)
+      expect(yaml.indexOf('"Drop"')).to.be.lessThan(yaml.indexOf('"Improve"'));
+    });
   });
 
   it("can import a YAML template and create a board from it", () => {

--- a/cypress/e2e/TemplateRoundTrip.cy.js
+++ b/cypress/e2e/TemplateRoundTrip.cy.js
@@ -23,6 +23,21 @@ function customiseFirstRank({ name, icon = false, color = false }) {
       .clear()
       .type(`${name}{enter}`);
     cy.wait("@patchRename");
+    // {enter} triggers on:submit which closes the options panel and dispatches a
+    // PATCH. Wait for the Firestore subscription to propagate the new name back
+    // to $ranks — confirmed when the card-text-input placeholder updates.
+    cy.get("[data-name=rank]:visible")
+      .first()
+      .find("[data-name=card-text-input]")
+      .invoke("attr", "placeholder")
+      .should("eq", name);
+    // Re-open the options panel if further changes are needed
+    if (icon || color) {
+      cy.get("[data-name=rank]:visible")
+        .first()
+        .find("[data-name=rank-options-button]")
+        .click();
+    }
   }
 
   if (icon) {

--- a/cypress/e2e/TemplateRoundTrip.cy.js
+++ b/cypress/e2e/TemplateRoundTrip.cy.js
@@ -11,16 +11,30 @@ function navigateToFirstBoard() {
 }
 
 function openRankOptionsIfClosed() {
+  // Use data-options-open (reflects $activeRankOptions store state, not CSS animation
+  // state) so we can reliably detect whether options are logically open or closed.
   cy.get("[data-name=rank]:visible")
     .first()
     .then(($rank) => {
-      if ($rank.find("[data-name=rank-options]").length === 0) {
+      if ($rank.attr("data-options-open") === "true") {
+        // Logically open — click to close so we reach a known-closed state.
         cy.get("[data-name=rank]:visible")
           .first()
           .find("[data-name=rank-options-button]")
           .click();
       }
     });
+  // Wait for the panel to be fully removed from the DOM (out:slide animation done).
+  cy.get("[data-name=rank]:visible")
+    .first()
+    .find("[data-name=rank-options]")
+    .should("not.exist");
+  // Open the panel.
+  cy.get("[data-name=rank]:visible")
+    .first()
+    .find("[data-name=rank-options-button]")
+    .click();
+  // Wait for the panel to be visible (in:slide animation done).
   cy.get("[data-name=rank]:visible")
     .first()
     .find("[data-name=rank-options]:visible")

--- a/cypress/e2e/TemplateRoundTrip.cy.js
+++ b/cypress/e2e/TemplateRoundTrip.cy.js
@@ -14,8 +14,11 @@ function openRankOptionsIfClosed() {
   cy.get("[data-name=rank]:visible")
     .first()
     .then(($rank) => {
-      if ($rank.find("[data-name=rank-options]:visible").length === 0) {
-        cy.wrap($rank).find("[data-name=rank-options-button]").click();
+      if ($rank.find("[data-name=rank-options]").length === 0) {
+        cy.get("[data-name=rank]:visible")
+          .first()
+          .find("[data-name=rank-options-button]")
+          .click();
       }
     });
   cy.get("[data-name=rank]:visible")

--- a/cypress/e2e/TemplateRoundTrip.cy.js
+++ b/cypress/e2e/TemplateRoundTrip.cy.js
@@ -10,19 +10,29 @@ function navigateToFirstBoard() {
   cy.get("[data-name=create-button]:visible").should("have.length", 0);
 }
 
-function customiseFirstRank({ name, icon = false, color = false }) {
+function openRankOptionsIfClosed() {
   cy.get("[data-name=rank]:visible")
     .first()
-    .find("[data-name=rank-options-button]")
-    .click();
+    .then(($rank) => {
+      if ($rank.find("[data-name=rank-options]:visible").length === 0) {
+        cy.wrap($rank).find("[data-name=rank-options-button]").click();
+      }
+    });
+  cy.get("[data-name=rank]:visible")
+    .first()
+    .find("[data-name=rank-options]:visible")
+    .should("exist");
+}
+
+function customiseFirstRank({ name, icon = false, color = false }) {
+  openRankOptionsIfClosed();
 
   if (name) {
     cy.intercept({ method: "patch", url: "boards/*/columns/*" }).as(
       "patchRename",
     );
     // Use .blur() instead of {enter} so on:submit is not triggered.
-    // on:submit sets $activeRankOptions = "" which would close the options panel,
-    // preventing subsequent icon/colour clicks without a re-open.
+    // on:submit sets $activeRankOptions = "" which would close the options panel.
     cy.get("[data-name=rank-options] input:visible")
       .first()
       .clear()
@@ -39,6 +49,7 @@ function customiseFirstRank({ name, icon = false, color = false }) {
   }
 
   if (icon) {
+    openRankOptionsIfClosed();
     cy.intercept({ method: "patch", url: "boards/*/columns/*" }).as(
       "patchIcon",
     );
@@ -48,6 +59,7 @@ function customiseFirstRank({ name, icon = false, color = false }) {
   }
 
   if (color) {
+    openRankOptionsIfClosed();
     cy.intercept({ method: "patch", url: "boards/*/columns/*" }).as(
       "patchColor",
     );

--- a/cypress/e2e/TemplateRoundTrip.cy.js
+++ b/cypress/e2e/TemplateRoundTrip.cy.js
@@ -245,9 +245,15 @@ context(
         expect(doc.columns[1].name).to.eq("Traurig");
         expect(doc.columns[2].name).to.eq("Glücklich");
         // i18n keys are preserved alongside the names
-        expect(doc.columns[0].key).to.eq("board.template.mad_sad_glad.column.mad");
-        expect(doc.columns[1].key).to.eq("board.template.mad_sad_glad.column.sad");
-        expect(doc.columns[2].key).to.eq("board.template.mad_sad_glad.column.glad");
+        expect(doc.columns[0].key).to.eq(
+          "board.template.mad_sad_glad.column.mad",
+        );
+        expect(doc.columns[1].key).to.eq(
+          "board.template.mad_sad_glad.column.sad",
+        );
+        expect(doc.columns[2].key).to.eq(
+          "board.template.mad_sad_glad.column.glad",
+        );
       });
     });
 
@@ -288,8 +294,12 @@ context(
         expect(doc.columns[0].name).to.eq("My Custom Column");
         expect(doc.columns[0].key).to.be.undefined;
         // Remaining built-in columns still have keys
-        expect(doc.columns[1].key).to.eq("board.template.mad_sad_glad.column.sad");
-        expect(doc.columns[2].key).to.eq("board.template.mad_sad_glad.column.glad");
+        expect(doc.columns[1].key).to.eq(
+          "board.template.mad_sad_glad.column.sad",
+        );
+        expect(doc.columns[2].key).to.eq(
+          "board.template.mad_sad_glad.column.glad",
+        );
       });
 
       // Import in German — built-in columns should appear in German,

--- a/cypress/e2e/TemplateRoundTrip.cy.js
+++ b/cypress/e2e/TemplateRoundTrip.cy.js
@@ -122,6 +122,22 @@ function setLocale(code) {
   cy.get(`[data-name=locale-select-${code}]`).click();
 }
 
+// On mobile only one rank is visible at a time; navigate via the tab strip first.
+function checkRankPlaceholder(index, expected) {
+  if (Cypress.config("viewportWidth") < 992) {
+    cy.get("[data-name=rank-tabs] label").eq(index).click();
+    cy.get("[data-name=rank]:visible")
+      .first()
+      .find("[data-name=card-text-input]")
+      .should("have.attr", "placeholder", expected);
+  } else {
+    cy.get("[data-name=rank]:visible")
+      .eq(index)
+      .find("[data-name=card-text-input]")
+      .should("have.attr", "placeholder", expected);
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 context("Template round-trip: customised board", () => {
@@ -173,27 +189,10 @@ context("Template round-trip: customised board", () => {
   it("board created from downloaded template has matching columns", () => {
     importTemplateAndCreate(DOWNLOAD_FILE, "Imported Customised Board");
 
-    // Custom name is stored literally — shows as-is
-    cy.get("[data-name=rank]:visible")
-      .eq(0)
-      .find("[data-name=card-text-input]")
-      .should("have.attr", "placeholder", CUSTOM_NAME);
-
-    // Built-in columns resolve via their i18n keys
-    cy.get("[data-name=rank]:visible")
-      .eq(1)
-      .find("[data-name=card-text-input]")
-      .should("have.attr", "placeholder", "Add");
-
-    cy.get("[data-name=rank]:visible")
-      .eq(2)
-      .find("[data-name=card-text-input]")
-      .should("have.attr", "placeholder", "Keep");
-
-    cy.get("[data-name=rank]:visible")
-      .eq(3)
-      .find("[data-name=card-text-input]")
-      .should("have.attr", "placeholder", "Improve");
+    checkRankPlaceholder(0, CUSTOM_NAME);
+    checkRankPlaceholder(1, "Add");
+    checkRankPlaceholder(2, "Keep");
+    checkRankPlaceholder(3, "Improve");
   });
 
   after(deleteAllBoards);
@@ -266,20 +265,9 @@ context(
       );
 
       // i18n keys resolve in the current locale (English), not the export locale
-      cy.get("[data-name=rank]:visible")
-        .eq(0)
-        .find("[data-name=card-text-input]")
-        .should("have.attr", "placeholder", "Mad");
-
-      cy.get("[data-name=rank]:visible")
-        .eq(1)
-        .find("[data-name=card-text-input]")
-        .should("have.attr", "placeholder", "Sad");
-
-      cy.get("[data-name=rank]:visible")
-        .eq(2)
-        .find("[data-name=card-text-input]")
-        .should("have.attr", "placeholder", "Glad");
+      checkRankPlaceholder(0, "Mad");
+      checkRankPlaceholder(1, "Sad");
+      checkRankPlaceholder(2, "Glad");
     });
 
     it("custom-named column stays literal while built-in columns translate to the import locale", () => {
@@ -319,21 +307,10 @@ context(
       cy.get("[data-name=create-button]:visible").should("have.length", 0);
 
       // Custom column: no key → stays as-is regardless of locale
-      cy.get("[data-name=rank]:visible")
-        .eq(0)
-        .find("[data-name=card-text-input]")
-        .should("have.attr", "placeholder", "My Custom Column");
-
+      checkRankPlaceholder(0, "My Custom Column");
       // Built-in columns: key → resolved in German
-      cy.get("[data-name=rank]:visible")
-        .eq(1)
-        .find("[data-name=card-text-input]")
-        .should("have.attr", "placeholder", "Traurig");
-
-      cy.get("[data-name=rank]:visible")
-        .eq(2)
-        .find("[data-name=card-text-input]")
-        .should("have.attr", "placeholder", "Glücklich");
+      checkRankPlaceholder(1, "Traurig");
+      checkRankPlaceholder(2, "Glücklich");
     });
 
     after(() => {

--- a/cypress/e2e/TemplateRoundTrip.cy.js
+++ b/cypress/e2e/TemplateRoundTrip.cy.js
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+import { load as loadYaml } from "js-yaml";
+
 // Helpers
 function navigateToFirstBoard() {
   cy.visit("/");
@@ -18,26 +20,22 @@ function customiseFirstRank({ name, icon = false, color = false }) {
     cy.intercept({ method: "patch", url: "boards/*/columns/*" }).as(
       "patchRename",
     );
+    // Use .blur() instead of {enter} so on:submit is not triggered.
+    // on:submit sets $activeRankOptions = "" which would close the options panel,
+    // preventing subsequent icon/colour clicks without a re-open.
     cy.get("[data-name=rank-options] input:visible")
       .first()
       .clear()
-      .type(`${name}{enter}`);
+      .type(name)
+      .blur();
     cy.wait("@patchRename");
-    // {enter} triggers on:submit which closes the options panel and dispatches a
-    // PATCH. Wait for the Firestore subscription to propagate the new name back
-    // to $ranks — confirmed when the card-text-input placeholder updates.
+    // Wait for the Firestore subscription to propagate the rename to $ranks —
+    // confirmed when the card-text-input placeholder reflects the new name.
     cy.get("[data-name=rank]:visible")
       .first()
       .find("[data-name=card-text-input]")
       .invoke("attr", "placeholder")
       .should("eq", name);
-    // Re-open the options panel if further changes are needed
-    if (icon || color) {
-      cy.get("[data-name=rank]:visible")
-        .first()
-        .find("[data-name=rank-options-button]")
-        .click();
-    }
   }
 
   if (icon) {
@@ -121,29 +119,24 @@ context("Template round-trip: customised board", () => {
 
     downloadTemplate();
 
-    cy.readFile(DOWNLOAD_FILE).then((yaml) => {
+    cy.readFile(DOWNLOAD_FILE).then((text) => {
+      const doc = loadYaml(text);
       // First column: custom name, new icon/colour, NO i18n key
-      expect(yaml).to.include(`name: ${CUSTOM_NAME}`);
-      expect(yaml).to.include("icon: award");
-      expect(yaml).to.include("color: plain");
-      expect(yaml).not.to.include(
-        "key: board.template.drop_add_keep_improve.column.drop",
-      );
-
+      expect(doc.columns[0]).to.include({
+        name: CUSTOM_NAME,
+        icon: "award",
+        color: "plain",
+      });
+      expect(doc.columns[0].key).to.be.undefined;
       // Remaining built-in columns still carry their i18n keys
-      expect(yaml).to.include(
-        "key: board.template.drop_add_keep_improve.column.add",
+      expect(doc.columns[1].key).to.eq(
+        "board.template.drop_add_keep_improve.column.add",
       );
-      expect(yaml).to.include(
-        "key: board.template.drop_add_keep_improve.column.keep",
+      expect(doc.columns[2].key).to.eq(
+        "board.template.drop_add_keep_improve.column.keep",
       );
-      expect(yaml).to.include(
-        "key: board.template.drop_add_keep_improve.column.improve",
-      );
-
-      // Custom column appears before Add (position order preserved)
-      expect(yaml.indexOf(CUSTOM_NAME)).to.be.lessThan(
-        yaml.indexOf("board.template.drop_add_keep_improve.column.add"),
+      expect(doc.columns[3].key).to.eq(
+        "board.template.drop_add_keep_improve.column.improve",
       );
     });
   });
@@ -205,7 +198,9 @@ context(
         },
       });
       cy.get("[data-name=board-list-button]").click();
-      cy.get("[data-name=board-row] td").first().click();
+      // BoardTable sorts newest-first, so after test 2 creates a second board
+      // the first row is no longer BOARD_NAME — navigate by name explicitly.
+      cy.contains("[data-name=board-row] td", BOARD_NAME).click();
       cy.get("[data-name=create-button]:visible").should("have.length", 0);
     });
 
@@ -214,16 +209,16 @@ context(
       setLocale("de");
       downloadTemplate();
 
-      cy.readFile(DOWNLOAD_FILE).then((yaml) => {
+      cy.readFile(DOWNLOAD_FILE).then((text) => {
+        const doc = loadYaml(text);
         // German translated names are present (human-readable)
-        expect(yaml).to.include("Wütend");
-        expect(yaml).to.include("Traurig");
-        expect(yaml).to.include("Glücklich");
-
+        expect(doc.columns[0].name).to.eq("Wütend");
+        expect(doc.columns[1].name).to.eq("Traurig");
+        expect(doc.columns[2].name).to.eq("Glücklich");
         // i18n keys are preserved alongside the names
-        expect(yaml).to.include("key: board.template.mad_sad_glad.column.mad");
-        expect(yaml).to.include("key: board.template.mad_sad_glad.column.sad");
-        expect(yaml).to.include("key: board.template.mad_sad_glad.column.glad");
+        expect(doc.columns[0].key).to.eq("board.template.mad_sad_glad.column.mad");
+        expect(doc.columns[1].key).to.eq("board.template.mad_sad_glad.column.sad");
+        expect(doc.columns[2].key).to.eq("board.template.mad_sad_glad.column.glad");
       });
     });
 
@@ -258,15 +253,14 @@ context(
 
       downloadTemplate();
 
-      cy.readFile(DOWNLOAD_FILE).then((yaml) => {
+      cy.readFile(DOWNLOAD_FILE).then((text) => {
+        const doc = loadYaml(text);
         // Custom name: no key field
-        expect(yaml).to.include("name: My Custom Column");
-        expect(yaml).not.to.include(
-          "key: board.template.mad_sad_glad.column.mad",
-        );
+        expect(doc.columns[0].name).to.eq("My Custom Column");
+        expect(doc.columns[0].key).to.be.undefined;
         // Remaining built-in columns still have keys
-        expect(yaml).to.include("key: board.template.mad_sad_glad.column.sad");
-        expect(yaml).to.include("key: board.template.mad_sad_glad.column.glad");
+        expect(doc.columns[1].key).to.eq("board.template.mad_sad_glad.column.sad");
+        expect(doc.columns[2].key).to.eq("board.template.mad_sad_glad.column.glad");
       });
 
       // Import in German — built-in columns should appear in German,

--- a/cypress/e2e/TemplateRoundTrip.cy.js
+++ b/cypress/e2e/TemplateRoundTrip.cy.js
@@ -1,0 +1,301 @@
+/// <reference types="cypress" />
+
+// Helpers
+function navigateToFirstBoard() {
+  cy.visit("/");
+  cy.get("[data-name=board-list-button]").click();
+  cy.get("[data-name=board-row] td").first().click();
+  cy.get("[data-name=create-button]:visible").should("have.length", 0);
+}
+
+function customiseFirstRank({ name, icon = false, color = false }) {
+  cy.get("[data-name=rank]:visible")
+    .first()
+    .find("[data-name=rank-options-button]")
+    .click();
+
+  if (name) {
+    cy.intercept({ method: "patch", url: "boards/*/columns/*" }).as(
+      "patchRename",
+    );
+    cy.get("[data-name=rank-options] input:visible")
+      .first()
+      .clear()
+      .type(`${name}{enter}`);
+    cy.wait("@patchRename");
+  }
+
+  if (icon) {
+    cy.intercept({ method: "patch", url: "boards/*/columns/*" }).as(
+      "patchIcon",
+    );
+    // Last icon in last row = "award"
+    cy.get("[data-name=rank-options-icons] > div:visible").last().click();
+    cy.wait("@patchIcon");
+  }
+
+  if (color) {
+    cy.intercept({ method: "patch", url: "boards/*/columns/*" }).as(
+      "patchColor",
+    );
+    // Last colour button = "plain"
+    cy.get("[data-name=rank-options-colors] > button:visible").last().click();
+    cy.wait("@patchColor");
+  }
+}
+
+function downloadTemplate() {
+  cy.get("[data-name=rank]:visible").should("have.length.at.least", 1);
+  cy.get("[data-name=menu-button]").click();
+  cy.get("[data-name=download-template-button]").click();
+  cy.get("[data-name=menu-button]").click();
+}
+
+function importTemplateAndCreate(yamlPath, boardName) {
+  cy.visit("/");
+  cy.get("[data-name=more-settings-button]").click();
+  cy.get('input[type="file"]').selectFile(yamlPath, { force: true });
+  cy.get("select").should("have.value", "custom");
+  cy.get("[data-name=board-name-input]").type(boardName);
+  cy.get("[data-name=create-button]").click();
+  cy.get("[data-name=create-button]:visible").should("have.length", 0);
+}
+
+function deleteAllBoards() {
+  cy.login();
+  cy.intercept("boards").as("getBoards");
+  cy.visit("/");
+  cy.wait("@getBoards");
+  cy.get("[data-name=board-list-button]").should("have.length", 1);
+  cy.get("[data-name=board-list-button]").click();
+  cy.get("[data-name=delete-button]").each(($el) => {
+    cy.wrap($el).click();
+    cy.get("[data-name=delete-confirm-button]").click();
+  });
+  cy.get("[data-name=board-table]").should("not.exist");
+}
+
+function setLocale(code) {
+  cy.get("[data-name=locale-select-button]").click();
+  cy.get(`[data-name=locale-select-${code}]`).click();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+context("Template round-trip: customised board", () => {
+  const BOARD_NAME = "Customised Round-Trip Board";
+  const CUSTOM_NAME = "Customised Column";
+  const DOWNLOAD_FILE = `cypress/downloads/retro-tools-${BOARD_NAME}-template.yaml`;
+
+  before(() => {
+    cy.login();
+    cy.visit("/");
+    cy.get("[data-name=board-name-input]").type(BOARD_NAME);
+    cy.get("[data-name=create-button]").click();
+    cy.get("[data-name=create-button]:visible").should("have.length", 0);
+  });
+
+  beforeEach(() => {
+    cy.login();
+    navigateToFirstBoard();
+  });
+
+  it("downloaded YAML reflects custom name, icon and colour — and preserves keys for unchanged columns", () => {
+    // Rename first column (Drop → custom), change icon to award, colour to plain
+    customiseFirstRank({ name: CUSTOM_NAME, icon: true, color: true });
+
+    downloadTemplate();
+
+    cy.readFile(DOWNLOAD_FILE).then((yaml) => {
+      // First column: custom name, new icon/colour, NO i18n key
+      expect(yaml).to.include(`name: ${CUSTOM_NAME}`);
+      expect(yaml).to.include("icon: award");
+      expect(yaml).to.include("color: plain");
+      expect(yaml).not.to.include(
+        "key: board.template.drop_add_keep_improve.column.drop",
+      );
+
+      // Remaining built-in columns still carry their i18n keys
+      expect(yaml).to.include(
+        "key: board.template.drop_add_keep_improve.column.add",
+      );
+      expect(yaml).to.include(
+        "key: board.template.drop_add_keep_improve.column.keep",
+      );
+      expect(yaml).to.include(
+        "key: board.template.drop_add_keep_improve.column.improve",
+      );
+
+      // Custom column appears before Add (position order preserved)
+      expect(yaml.indexOf(CUSTOM_NAME)).to.be.lessThan(
+        yaml.indexOf("board.template.drop_add_keep_improve.column.add"),
+      );
+    });
+  });
+
+  it("board created from downloaded template has matching columns", () => {
+    importTemplateAndCreate(DOWNLOAD_FILE, "Imported Customised Board");
+
+    // Custom name is stored literally — shows as-is
+    cy.get("[data-name=rank]:visible")
+      .eq(0)
+      .find("[data-name=card-text-input]")
+      .should("have.attr", "placeholder", CUSTOM_NAME);
+
+    // Built-in columns resolve via their i18n keys
+    cy.get("[data-name=rank]:visible")
+      .eq(1)
+      .find("[data-name=card-text-input]")
+      .should("have.attr", "placeholder", "Add");
+
+    cy.get("[data-name=rank]:visible")
+      .eq(2)
+      .find("[data-name=card-text-input]")
+      .should("have.attr", "placeholder", "Keep");
+
+    cy.get("[data-name=rank]:visible")
+      .eq(3)
+      .find("[data-name=card-text-input]")
+      .should("have.attr", "placeholder", "Improve");
+  });
+
+  after(deleteAllBoards);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+context(
+  "Template round-trip: i18n key preservation across locale change",
+  () => {
+    const BOARD_NAME = "i18n Round-Trip Board";
+    const DOWNLOAD_FILE = `cypress/downloads/retro-tools-${BOARD_NAME}-template.yaml`;
+
+    before(() => {
+      cy.login();
+      // Create a Mad/Sad/Glad board — all built-in column names, none renamed
+      cy.visit("/");
+      cy.get("[data-name=board-name-input]").type(BOARD_NAME);
+      cy.get("[data-name=more-settings-button]").click();
+      cy.get("select").select("madSadGlad");
+      cy.get("[data-name=create-button]").click();
+      cy.get("[data-name=create-button]:visible").should("have.length", 0);
+    });
+
+    beforeEach(() => {
+      cy.login();
+      // Always start in English so locale state is deterministic
+      cy.visit("/", {
+        onBeforeLoad(win) {
+          win.localStorage.setItem("locale", "en");
+        },
+      });
+      cy.get("[data-name=board-list-button]").click();
+      cy.get("[data-name=board-row] td").first().click();
+      cy.get("[data-name=create-button]:visible").should("have.length", 0);
+    });
+
+    it("exported YAML contains the locale's translated name AND the i18n key", () => {
+      // Switch to German, then export
+      setLocale("de");
+      downloadTemplate();
+
+      cy.readFile(DOWNLOAD_FILE).then((yaml) => {
+        // German translated names are present (human-readable)
+        expect(yaml).to.include("Wütend");
+        expect(yaml).to.include("Traurig");
+        expect(yaml).to.include("Glücklich");
+
+        // i18n keys are preserved alongside the names
+        expect(yaml).to.include("key: board.template.mad_sad_glad.column.mad");
+        expect(yaml).to.include("key: board.template.mad_sad_glad.column.sad");
+        expect(yaml).to.include("key: board.template.mad_sad_glad.column.glad");
+      });
+    });
+
+    // Depends on the file downloaded by the previous test
+    it("board created from a German-exported template shows columns in the import locale", () => {
+      // Still in English (reset by beforeEach) — import the German-exported file
+      importTemplateAndCreate(
+        DOWNLOAD_FILE,
+        "English Board from German Template",
+      );
+
+      // i18n keys resolve in the current locale (English), not the export locale
+      cy.get("[data-name=rank]:visible")
+        .eq(0)
+        .find("[data-name=card-text-input]")
+        .should("have.attr", "placeholder", "Mad");
+
+      cy.get("[data-name=rank]:visible")
+        .eq(1)
+        .find("[data-name=card-text-input]")
+        .should("have.attr", "placeholder", "Sad");
+
+      cy.get("[data-name=rank]:visible")
+        .eq(2)
+        .find("[data-name=card-text-input]")
+        .should("have.attr", "placeholder", "Glad");
+    });
+
+    it("custom-named column stays literal while built-in columns translate to the import locale", () => {
+      // Rename the first column — this removes the i18n key from the export
+      customiseFirstRank({ name: "My Custom Column" });
+
+      downloadTemplate();
+
+      cy.readFile(DOWNLOAD_FILE).then((yaml) => {
+        // Custom name: no key field
+        expect(yaml).to.include("name: My Custom Column");
+        expect(yaml).not.to.include(
+          "key: board.template.mad_sad_glad.column.mad",
+        );
+        // Remaining built-in columns still have keys
+        expect(yaml).to.include("key: board.template.mad_sad_glad.column.sad");
+        expect(yaml).to.include("key: board.template.mad_sad_glad.column.glad");
+      });
+
+      // Import in German — built-in columns should appear in German,
+      // but the renamed column should stay as its literal English name
+      cy.visit("/", {
+        onBeforeLoad(win) {
+          win.localStorage.setItem("locale", "de");
+        },
+      });
+      cy.get("[data-name=more-settings-button]").click();
+      cy.get('input[type="file"]').selectFile(DOWNLOAD_FILE, { force: true });
+      cy.get("select").should("have.value", "custom");
+      cy.get("[data-name=board-name-input]").type(
+        "German Board with Custom Column",
+      );
+      cy.get("[data-name=create-button]").click();
+      cy.get("[data-name=create-button]:visible").should("have.length", 0);
+
+      // Custom column: no key → stays as-is regardless of locale
+      cy.get("[data-name=rank]:visible")
+        .eq(0)
+        .find("[data-name=card-text-input]")
+        .should("have.attr", "placeholder", "My Custom Column");
+
+      // Built-in columns: key → resolved in German
+      cy.get("[data-name=rank]:visible")
+        .eq(1)
+        .find("[data-name=card-text-input]")
+        .should("have.attr", "placeholder", "Traurig");
+
+      cy.get("[data-name=rank]:visible")
+        .eq(2)
+        .find("[data-name=card-text-input]")
+        .should("have.attr", "placeholder", "Glücklich");
+    });
+
+    after(() => {
+      // Reset locale before cleanup so board list renders predictably
+      cy.visit("/", {
+        onBeforeLoad(win) {
+          win.localStorage.setItem("locale", "en");
+        },
+      });
+      deleteAllBoards();
+    });
+  },
+);

--- a/cypress/fixtures/template.yaml
+++ b/cypress/fixtures/template.yaml
@@ -1,0 +1,7 @@
+columns:
+  - name: "Went well"
+    icon: thumbsup
+    color: green
+  - name: "Didn't go well"
+    icon: thumbsdown
+    color: red

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,13 @@
         "dragula": "^3.7.3",
         "firebase": "^12.12.0",
         "jose": "^6",
+        "js-yaml": "^4.1.1",
         "moment": "^2.29.4"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7",
         "@sveltestrap/sveltestrap": "^7",
+        "@types/js-yaml": "^4.0.9",
         "cypress": "^15.13.1",
         "eslint": "^10.2.0",
         "eslint-config-prettier": "^10.1.8",
@@ -1732,6 +1734,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1924,6 +1933,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.1",
@@ -3950,6 +3965,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/jsbn": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7",
     "@sveltestrap/sveltestrap": "^7",
+    "@types/js-yaml": "^4.0.9",
     "cypress": "^15.13.1",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
@@ -35,6 +36,7 @@
     "dragula": "^3.7.3",
     "firebase": "^12.12.0",
     "jose": "^6",
+    "js-yaml": "^4.1.1",
     "moment": "^2.29.4"
   }
 }

--- a/src/Board.svelte
+++ b/src/Board.svelte
@@ -140,8 +140,9 @@
     ranks.set(await getRanks(boardId));
     await checkPassword();
 
-    // Show first rank initially
-    if ($ranks[0]) $focusedRank = $ranks[0].id;
+    // Show first rank initially (by position, not API order)
+    const firstRank = [...$ranks].sort((a, b) => a.position - b.position)[0];
+    if (firstRank) $focusedRank = firstRank.id;
 
     // Subscribe to local changes to $board so we can post updates.
     // Compare updated boards to their last known value

--- a/src/Splash.svelte
+++ b/src/Splash.svelte
@@ -233,7 +233,7 @@
     in:fly={{ y: 100, duration: 200 }}
     out:fly={{ y: 100, duration: 200 }}
   >
-    <Alert class="fixed-bottom mb-0 py-1" color="danger" isOpen={true}>
+    <Alert data-name="error-alert" class="fixed-bottom mb-0 py-1" color="danger" isOpen={true}>
       {$_(errorAlertMessage)}
     </Alert>
   </div>

--- a/src/Splash.svelte
+++ b/src/Splash.svelte
@@ -233,7 +233,12 @@
     in:fly={{ y: 100, duration: 200 }}
     out:fly={{ y: 100, duration: 200 }}
   >
-    <Alert data-name="error-alert" class="fixed-bottom mb-0 py-1" color="danger" isOpen={true}>
+    <Alert
+      data-name="error-alert"
+      class="fixed-bottom mb-0 py-1"
+      color="danger"
+      isOpen={true}
+    >
       {$_(errorAlertMessage)}
     </Alert>
   </div>

--- a/src/components/CreateForm.svelte
+++ b/src/components/CreateForm.svelte
@@ -3,6 +3,7 @@
   import { _ } from "svelte-i18n";
   import { slide } from "svelte/transition";
   import { UploadIcon } from "svelte-feather-icons";
+  import { load as loadYaml } from "js-yaml";
 
   import { Icons, BoardTemplates } from "../data.js";
   import { colorMode, darkMode, password } from "../store.js";
@@ -36,53 +37,20 @@
   ]);
   const validIcons = new Set(Object.keys(Icons));
 
-  function parseYamlString(val) {
-    val = val.trim();
-    if (val.startsWith('"') && val.endsWith('"')) {
-      return val.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
-    }
-    if (val.startsWith("'") && val.endsWith("'")) {
-      return val.slice(1, -1).replace(/''/g, "'");
-    }
-    return val;
-  }
-
   function parseYamlTemplate(content) {
-    const lines = content.split("\n");
-    const ranks = [];
-    let current = null;
-    for (const line of lines) {
-      const nameMatch = line.match(/^\s+-\s+name:\s*(.*)/);
-      if (nameMatch) {
-        if (current) ranks.push(current);
-        current = {
-          name: parseYamlString(nameMatch[1]),
-          icon: "plus",
-          color: "plain",
-          position: ranks.length,
-        };
-        continue;
-      }
-      if (current) {
-        const iconMatch = line.match(/^\s+icon:\s*(.*)/);
-        if (iconMatch) {
-          const icon = parseYamlString(iconMatch[1]);
-          if (validIcons.has(icon)) current.icon = icon;
-          continue;
-        }
-        const colorMatch = line.match(/^\s+color:\s*(.*)/);
-        if (colorMatch) {
-          const color = parseYamlString(colorMatch[1]);
-          if (validColors.has(color)) current.color = color;
-          continue;
-        }
-      }
-    }
-    if (current) ranks.push(current);
-    return {
-      name: "board.template.custom.name",
-      ranks: ranks.map((r, i) => ({ ...r, position: i })),
-    };
+    const doc = loadYaml(content);
+    const columns =
+      doc != null && typeof doc === "object" && "columns" in doc
+        ? doc.columns
+        : null;
+    if (!Array.isArray(columns)) throw new Error("missing columns");
+    const ranks = columns.map((col, i) => ({
+      name: String(col.key ?? col.name ?? ""),
+      icon: validIcons.has(col.icon) ? col.icon : "plus",
+      color: validColors.has(col.color) ? col.color : "plain",
+      position: i,
+    }));
+    return { name: "board.template.custom.name", ranks };
   }
 
   function handleFileImport(event) {

--- a/src/components/CreateForm.svelte
+++ b/src/components/CreateForm.svelte
@@ -2,6 +2,7 @@
   import { createEventDispatcher } from "svelte";
   import { _ } from "svelte-i18n";
   import { slide } from "svelte/transition";
+  import { UploadIcon } from "svelte-feather-icons";
 
   import { Icons, BoardTemplates } from "../data.js";
   import { colorMode, darkMode, password } from "../store.js";
@@ -17,11 +18,93 @@
   const dispatch = createEventDispatcher();
   let boardName = $state("");
   let templateKey = $state("dropAddKeepImprove");
+  let customTemplate = $state(null);
+  let fileInput = $state(null);
   let iceBreakingQuestion = $state("");
   let passwordDisabled = $state(true);
   let showPassword = $state(false);
   let createBusy = $state(false);
   let optionsExpanded = $state(false);
+
+  const validColors = new Set([
+    "red",
+    "green",
+    "blue",
+    "yellow",
+    "cyan",
+    "plain",
+  ]);
+  const validIcons = new Set(Object.keys(Icons));
+
+  function parseYamlString(val) {
+    val = val.trim();
+    if (val.startsWith('"') && val.endsWith('"')) {
+      return val.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+    }
+    if (val.startsWith("'") && val.endsWith("'")) {
+      return val.slice(1, -1).replace(/''/g, "'");
+    }
+    return val;
+  }
+
+  function parseYamlTemplate(content) {
+    const lines = content.split("\n");
+    const ranks = [];
+    let current = null;
+    for (const line of lines) {
+      const nameMatch = line.match(/^\s+-\s+name:\s*(.*)/);
+      if (nameMatch) {
+        if (current) ranks.push(current);
+        current = {
+          name: parseYamlString(nameMatch[1]),
+          icon: "plus",
+          color: "plain",
+          position: ranks.length,
+        };
+        continue;
+      }
+      if (current) {
+        const iconMatch = line.match(/^\s+icon:\s*(.*)/);
+        if (iconMatch) {
+          const icon = parseYamlString(iconMatch[1]);
+          if (validIcons.has(icon)) current.icon = icon;
+          continue;
+        }
+        const colorMatch = line.match(/^\s+color:\s*(.*)/);
+        if (colorMatch) {
+          const color = parseYamlString(colorMatch[1]);
+          if (validColors.has(color)) current.color = color;
+          continue;
+        }
+      }
+    }
+    if (current) ranks.push(current);
+    return {
+      name: "board.template.custom.name",
+      ranks: ranks.map((r, i) => ({ ...r, position: i })),
+    };
+  }
+
+  function handleFileImport(event) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const template = parseYamlTemplate(e.target.result);
+        if (template.ranks.length === 0) {
+          dispatch("error", { message: "error.invalid_template" });
+          return;
+        }
+        customTemplate = template;
+        templateKey = "custom";
+      } catch (err) {
+        dispatch("error", { message: "error.invalid_template", err });
+      }
+    };
+    reader.readAsText(file);
+    event.target.value = "";
+  }
 
   async function createFromTemplate(template) {
     let [boardNameEncrypted, encryptionTest, iceBreakingQuestionEncrypted] =
@@ -50,7 +133,11 @@
       password.set("");
     }
     try {
-      const board = await createFromTemplate(BoardTemplates[templateKey]);
+      const template =
+        templateKey === "custom" && customTemplate
+          ? customTemplate
+          : BoardTemplates[templateKey];
+      const board = await createFromTemplate(template);
       dispatch("created", board.id);
     } catch (err) {
       dispatch("error", { message: "error.creating_board", err });
@@ -102,11 +189,31 @@
   {#if optionsExpanded}
     <div in:slide out:slide>
       <p class="my-1 small">{$_("splash.template")}</p>
-      <Select bind:value={templateKey}>
-        {#each Object.entries(BoardTemplates) as [key, template] (key)}
-          <option value={key}>{$_(template.name)}</option>
-        {/each}
-      </Select>
+      <div class="d-flex gap-2">
+        <Select bind:value={templateKey}>
+          {#each Object.entries(BoardTemplates) as [key, template] (key)}
+            <option value={key}>{$_(template.name)}</option>
+          {/each}
+          {#if customTemplate}
+            <option value="custom">{$_("board.template.custom.name")}</option>
+          {/if}
+        </Select>
+        <input
+          type="file"
+          accept=".yaml,.yml"
+          class="d-none"
+          bind:this={fileInput}
+          onchange={handleFileImport}
+        />
+        <Button
+          color={$colorMode}
+          textColor="body"
+          on:click={() => fileInput.click()}
+          title={$_("splash.import_template")}
+        >
+          <UploadIcon size="1x" />
+        </Button>
+      </div>
       <p class="my-1 small">{$_("general.encryption")}</p>
       <div class="input-group">
         <div class="input-group-text">

--- a/src/components/Menu.svelte
+++ b/src/components/Menu.svelte
@@ -60,6 +60,29 @@
     return str;
   }
 
+  function yamlString(str) {
+    return '"' + str.replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
+  }
+
+  async function downloadTemplate() {
+    const sortedRanks = [...$ranks].sort((a, b) => a.position - b.position);
+    let yaml = "columns:\n";
+    for (const rank of sortedRanks) {
+      const name = $_(rank.name);
+      yaml += `  - name: ${yamlString(name)}\n`;
+      yaml += `    icon: ${rank.data.icon}\n`;
+      yaml += `    color: ${rank.data.color}\n`;
+    }
+    const blob = new Blob([yaml], { type: "text/yaml" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    const boardName = await decrypt($board.name, $password);
+    a.download = `${boardName}-template.yaml`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
   async function downloadCSV() {
     const rankMap = Object.fromEntries($ranks.map((r) => [r.id, r]));
     const rows = await Promise.all(
@@ -220,6 +243,15 @@
         <Icons.download class="align-top" size="1x" />
       </div>
       {$_("board.options.download_csv")}
+    </DropdownItem>
+    <DropdownItem
+      data-name="download-template-button"
+      on:click={downloadTemplate}
+    >
+      <div class="d-inline-block icon position-relative" style="top: 2px">
+        <Icons.columns class="align-top" size="1x" />
+      </div>
+      {$_("board.options.download_template")}
     </DropdownItem>
     <DropdownItem
       data-name="copy-link-button"

--- a/src/components/Menu.svelte
+++ b/src/components/Menu.svelte
@@ -23,6 +23,7 @@
   } from "../store.js";
   import { createRank } from "../api.js";
   import { decrypt } from "../encryption.js";
+  import { dump as dumpYaml } from "js-yaml";
 
   import QRCode from "./QRCode.svelte";
   import Timer from "./Timer.svelte";
@@ -60,20 +61,15 @@
     return str;
   }
 
-  function yamlString(str) {
-    return '"' + str.replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
-  }
-
   async function downloadTemplate() {
     const sortedRanks = [...$ranks].sort((a, b) => a.position - b.position);
-    let yaml = "columns:\n";
-    for (const rank of sortedRanks) {
+    const columns = sortedRanks.map((rank) => {
       const name = $_(rank.name);
-      yaml += `  - name: ${yamlString(name)}\n`;
-      if (name !== rank.name) yaml += `    key: ${rank.name}\n`;
-      yaml += `    icon: ${rank.data.icon}\n`;
-      yaml += `    color: ${rank.data.color}\n`;
-    }
+      const col = { name, icon: rank.data.icon, color: rank.data.color };
+      if (name !== rank.name) col.key = rank.name;
+      return col;
+    });
+    const yaml = dumpYaml({ columns });
     const blob = new Blob([yaml], { type: "text/yaml" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/src/components/Menu.svelte
+++ b/src/components/Menu.svelte
@@ -78,7 +78,7 @@
     const a = document.createElement("a");
     a.href = url;
     const boardName = await decrypt($board.name, $password);
-    a.download = `${boardName}-template.yaml`;
+    a.download = `retro-tools-${boardName}-template.yaml`;
     a.click();
     URL.revokeObjectURL(url);
   }

--- a/src/components/Menu.svelte
+++ b/src/components/Menu.svelte
@@ -70,6 +70,7 @@
     for (const rank of sortedRanks) {
       const name = $_(rank.name);
       yaml += `  - name: ${yamlString(name)}\n`;
+      if (name !== rank.name) yaml += `    key: ${rank.name}\n`;
       yaml += `    icon: ${rank.data.icon}\n`;
       yaml += `    color: ${rank.data.color}\n`;
     }

--- a/src/components/Rank.svelte
+++ b/src/components/Rank.svelte
@@ -117,6 +117,7 @@
 
 <div
   data-name="rank"
+  data-options-open={$activeRankOptions === rank.id}
   class="rank flex-grow-0 flex-shrink-0 px-3 {columnWidth}"
   class:busy={rank.busy}
 >

--- a/src/components/RankOptions.svelte
+++ b/src/components/RankOptions.svelte
@@ -49,7 +49,7 @@
     {#each Object.entries($colors) as [name, color] (name)}
       <SSButton
         style="background-color: {color};"
-        on:click={() => {
+        onclick={() => {
           rank.data.color = name;
           doUpdate();
         }}

--- a/src/components/RankOptions.svelte
+++ b/src/components/RankOptions.svelte
@@ -2,7 +2,7 @@
   import clsx from "clsx";
   import { createEventDispatcher } from "svelte";
   import { dictionary, _ } from "svelte-i18n";
-  import { ButtonGroup, Button as SSButton } from "@sveltestrap/sveltestrap";
+  import { Button as SSButton } from "@sveltestrap/sveltestrap";
 
   import { updateRank } from "../api";
   import { ColumnIcons, Icons } from "../data";
@@ -45,7 +45,7 @@
       doUpdate();
     }}
   />
-  <ButtonGroup class="w-100 m-1" data-name="rank-options-colors">
+  <div class="btn-group w-100 m-1" role="group" data-name="rank-options-colors">
     {#each Object.entries($colors) as [name, color] (name)}
       <SSButton
         style="background-color: {color};"
@@ -59,7 +59,7 @@
         {/if}
       </SSButton>
     {/each}
-  </ButtonGroup>
+  </div>
   {#each ColumnIcons as row, i (i)}
     <div
       class="w-100 mx-1 d-flex justify-content-around w-100 my-1"

--- a/src/lang/de.json
+++ b/src/lang/de.json
@@ -53,6 +53,7 @@
   "board.options.sort_by_votes": "Nach Bewertungen sortieren",
   "board.options.show_qr_code": "QR-Code anzeigen",
   "board.options.download_csv": "CSV herunterladen",
+  "board.options.download_template": "Vorlage herunterladen",
   "board.options.copy_link": "Link kopieren",
   "board.options.new_column": "Neue Spalte",
   "board.options.obscure_cards": "Karten verbergen",
@@ -86,5 +87,8 @@
   "board.timer.start": "Starten",
   "board.timer.stop": "Stoppen",
   "board.timer.reset": "Zurücksetzen",
-  "board.timer.times_up": "Zeit abgelaufen!"
+  "board.timer.times_up": "Zeit abgelaufen!",
+  "splash.import_template": "Vorlage importieren",
+  "board.template.custom.name": "Benutzerdefiniert (importiert)",
+  "error.invalid_template": "Ungültige Vorlagendatei"
 }

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -54,6 +54,7 @@
   "board.options.sort_by_votes": "Sort by Votes",
   "board.options.show_qr_code": "Show QR Code",
   "board.options.download_csv": "Download CSV",
+  "board.options.download_template": "Download Template",
   "board.options.copy_link": "Copy Link",
   "board.options.new_column": "New Column",
   "board.options.open_permission": "Everyone is Admin",
@@ -87,5 +88,8 @@
   "board.timer.start": "Start",
   "board.timer.stop": "Stop",
   "board.timer.reset": "Reset",
-  "board.timer.times_up": "Time's up!"
+  "board.timer.times_up": "Time's up!",
+  "splash.import_template": "Import Template",
+  "board.template.custom.name": "Custom (imported)",
+  "error.invalid_template": "Invalid template file"
 }

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -53,6 +53,7 @@
   "board.options.sort_by_votes": "Ordenar por Votos",
   "board.options.show_qr_code": "Mostrar Código QR",
   "board.options.download_csv": "Descargar CSV",
+  "board.options.download_template": "Descargar plantilla",
   "board.options.copy_link": "Copiar Enlace",
   "board.options.new_column": "Nueva Columna",
   "board.options.obscure_cards": "Ocultar tarjetas",
@@ -86,5 +87,8 @@
   "board.timer.start": "Iniciar",
   "board.timer.stop": "Detener",
   "board.timer.reset": "Reiniciar",
-  "board.timer.times_up": "¡Tiempo agotado!"
+  "board.timer.times_up": "¡Tiempo agotado!",
+  "splash.import_template": "Importar plantilla",
+  "board.template.custom.name": "Personalizado (importado)",
+  "error.invalid_template": "Archivo de plantilla no válido"
 }

--- a/src/lang/ko.json
+++ b/src/lang/ko.json
@@ -53,6 +53,7 @@
   "board.options.sort_by_votes": "투표수로 정렬하기",
   "board.options.show_qr_code": "QR 코드 보기",
   "board.options.download_csv": "CSV 다운로드",
+  "board.options.download_template": "템플릿 다운로드",
   "board.options.copy_link": "링크 복사하기",
   "board.options.new_column": "새로운 컬럼이",
   "board.options.obscure_cards": "카드 가리기",
@@ -86,5 +87,8 @@
   "board.timer.start": "시작",
   "board.timer.stop": "정지",
   "board.timer.reset": "재설정",
-  "board.timer.times_up": "시간이 종료되었습니다!"
+  "board.timer.times_up": "시간이 종료되었습니다!",
+  "splash.import_template": "템플릿 가져오기",
+  "board.template.custom.name": "사용자 정의 (가져옴)",
+  "error.invalid_template": "잘못된 템플릿 파일"
 }

--- a/src/lang/pt_BR.json
+++ b/src/lang/pt_BR.json
@@ -54,6 +54,7 @@
   "board.options.sort_by_votes": "Ordenar por Votos",
   "board.options.show_qr_code": "Mostrar Código QR",
   "board.options.download_csv": "Baixar CSV",
+  "board.options.download_template": "Baixar modelo",
   "board.options.copy_link": "Copiar Link",
   "board.options.new_column": "Nova Coluna",
   "board.options.obscure_cards": "Ocultar cartões",
@@ -87,5 +88,8 @@
   "board.timer.start": "Iniciar",
   "board.timer.stop": "Parar",
   "board.timer.reset": "Reiniciar",
-  "board.timer.times_up": "Tempo esgotado!"
+  "board.timer.times_up": "Tempo esgotado!",
+  "splash.import_template": "Importar modelo",
+  "board.template.custom.name": "Personalizado (importado)",
+  "error.invalid_template": "Arquivo de modelo inválido"
 }

--- a/src/lang/ru.json
+++ b/src/lang/ru.json
@@ -54,6 +54,7 @@
   "board.options.sort_by_votes": "Сортировать по голосам",
   "board.options.show_qr_code": "Показать QR-код",
   "board.options.download_csv": "Скачать CSV",
+  "board.options.download_template": "Скачать шаблон",
   "board.options.copy_link": "Копировать ссылку на доску",
   "board.options.new_column": "Новая столбец",
   "board.options.obscure_cards": "Скрыть карточки",
@@ -86,5 +87,8 @@
   "board.timer.start": "Старт",
   "board.timer.stop": "Стоп",
   "board.timer.reset": "Сбросить",
-  "board.timer.times_up": "Время вышло!"
+  "board.timer.times_up": "Время вышло!",
+  "splash.import_template": "Импортировать шаблон",
+  "board.template.custom.name": "Пользовательский (импортированный)",
+  "error.invalid_template": "Неверный файл шаблона"
 }

--- a/src/lang/tr.json
+++ b/src/lang/tr.json
@@ -54,6 +54,7 @@
   "board.options.sort_by_votes": "Oylara göre sırala",
   "board.options.show_qr_code": "QR kodu göster",
   "board.options.download_csv": "CSV olarak indir",
+  "board.options.download_template": "Şablonu indir",
   "board.options.copy_link": "Linki kopyala",
   "board.options.new_column": "Yeni sütün ekle",
   "board.options.obscure_cards": "Kartları gizle",
@@ -87,5 +88,8 @@
   "board.timer.start": "Başlat",
   "board.timer.stop": "Durdur",
   "board.timer.reset": "Sıfırla",
-  "board.timer.times_up": "Süre doldu!"
+  "board.timer.times_up": "Süre doldu!",
+  "splash.import_template": "Şablon içe aktar",
+  "board.template.custom.name": "Özel (içe aktarıldı)",
+  "error.invalid_template": "Geçersiz şablon dosyası"
 }

--- a/src/lang/uk.json
+++ b/src/lang/uk.json
@@ -54,6 +54,7 @@
   "board.options.sort_by_votes": "Сортувати по голосам",
   "board.options.show_qr_code": "Показати QR код",
   "board.options.download_csv": "Завантажити CSV",
+  "board.options.download_template": "Завантажити шаблон",
   "board.options.copy_link": "Скопіювати посилання",
   "board.options.new_column": "Новий стовпець",
   "board.options.obscure_cards": "Приховати картки",
@@ -87,5 +88,8 @@
   "board.timer.start": "Старт",
   "board.timer.stop": "Стоп",
   "board.timer.reset": "Скинути",
-  "board.timer.times_up": "Час вийшов!"
+  "board.timer.times_up": "Час вийшов!",
+  "splash.import_template": "Імпортувати шаблон",
+  "board.template.custom.name": "Користувацький (імпортований)",
+  "error.invalid_template": "Невірний файл шаблону"
 }


### PR DESCRIPTION
## Summary

- **Export**: adds a \"Download Template\" item to the board menu (next to \"Download CSV\") that generates a `.yaml` file from the current board's columns — translated name, icon, and colour
- **Import**: adds an upload button beside the template dropdown on the create form; selecting a `.yaml`/`.yml` file parses it and auto-selects it as \"Custom (imported)\" in the template list
- Invalid icons/colours fall back to `plus`/`plain` gracefully; an empty or unparseable file shows an error toast

**YAML format:**
\`\`\`yaml
columns:
  - name: "Went well"
    icon: thumbsup
    color: green
  - name: "Didn't go well"
    icon: thumbsdown
    color: red
\`\`\`

## Test plan

- [ ] On an existing board, open the menu → \"Download Template\" → verify a `.yaml` file downloads with the correct columns, icons, and colours
- [ ] On the create page, expand \"more settings\", click the upload icon, select the downloaded template → verify \"Custom (imported)\" appears and is selected
- [ ] Create a board from the imported template → verify columns match the original
- [ ] Upload a `.yaml` with an unrecognised icon/colour → verify it falls back gracefully
- [ ] Upload an empty or malformed file → verify the error toast appears
- [ ] Existing CSV download and built-in templates are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)