### PR TITLE
fix: correct CSV export timestamp

### DIFF
--- a/cypress/e2e/Menu.cy.js
+++ b/cypress/e2e/Menu.cy.js
@@ -167,6 +167,42 @@ context("Menu", () => {
     cy.get("[data-name=card]").should("not.exist");
   });
 
+  it("csv created_at timestamp is within 24 hours of the current time", () => {
+    const cardText = "Timestamp test card";
+
+    cy.get("[data-name=rank]:visible")
+      .first()
+      .find("[data-name=card-text-input]")
+      .type(`${cardText}{enter}`)
+      .should("have.value", "");
+    cy.get("[data-name=card]:visible").should("exist");
+
+    cy.get("[data-name=menu-button]").click();
+    cy.get("[data-name=download-csv-button]").click();
+
+    const date = new Date().toISOString().slice(0, 10);
+    cy.readFile(`cypress/downloads/Test Board Name-${date}.csv`).then((csv) => {
+      const [, ...rows] = csv.trim().split("\n");
+      const match = rows.find((row) => row.includes(cardText));
+      expect(match).to.exist;
+      // created_at is the 4th field: column,author,text,created_at,votes
+      const createdAt = match.split(",")[3];
+      const timestamp = new Date(createdAt);
+      expect(timestamp.toString()).to.not.equal("Invalid Date");
+      const oneDayMs = 24 * 60 * 60 * 1000;
+      expect(timestamp.getTime()).to.be.within(
+        Date.now() - oneDayMs,
+        Date.now() + oneDayMs,
+      );
+    });
+
+    cy.get("[data-name=card]")
+      .find("[data-name=delete-button]:visible")
+      .click({ multiple: true });
+    cy.get("[data-name=confirm-button]:visible").click({ multiple: true });
+    cy.get("[data-name=card]").should("not.exist");
+  });
+
   it("has the board link as its clipboard data", () => {
     cy.get("[data-name=copy-link-button]")
       .should("have.attr", "data-clipboard-text")

--- a/cypress/e2e/TemplateRoundTrip.cy.js
+++ b/cypress/e2e/TemplateRoundTrip.cy.js
@@ -276,19 +276,23 @@ context(
 
       downloadTemplate();
 
-      cy.readFile(DOWNLOAD_FILE).then((text) => {
-        const doc = loadYaml(text);
-        // Custom name: no key field
-        expect(doc.columns[0].name).to.eq("My Custom Column");
-        expect(doc.columns[0].key).to.be.undefined;
-        // Remaining built-in columns still have keys
-        expect(doc.columns[1].key).to.eq(
-          "board.template.mad_sad_glad.column.sad",
-        );
-        expect(doc.columns[2].key).to.eq(
-          "board.template.mad_sad_glad.column.glad",
-        );
-      });
+      // The file already exists from the German-export test in this context.
+      // Use .should() so Cypress retries readFile until the download overwrites it.
+      cy.readFile(DOWNLOAD_FILE)
+        .should("include", "My Custom Column")
+        .then((text) => {
+          const doc = loadYaml(text);
+          // Custom name: no key field
+          expect(doc.columns[0].name).to.eq("My Custom Column");
+          expect(doc.columns[0].key).to.be.undefined;
+          // Remaining built-in columns still have keys
+          expect(doc.columns[1].key).to.eq(
+            "board.template.mad_sad_glad.column.sad",
+          );
+          expect(doc.columns[2].key).to.eq(
+            "board.template.mad_sad_glad.column.glad",
+          );
+        });
 
       // Import in German — built-in columns should appear in German,
       // but the renamed column should stay as its literal English name

--- a/src/components/Menu.svelte
+++ b/src/components/Menu.svelte
@@ -88,7 +88,7 @@
         const column = rank ? $_(rank.name) : "";
         const author = await decrypt(card.author, $password);
         const text = await decrypt(card.text, $password);
-        const createdAt = new Date(card.created_at * 1000).toISOString();
+        const createdAt = card.created_at.toISOString();
         return [column, author, text, createdAt, card.votes]
           .map(csvEscape)
           .join(",");

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -120,7 +120,7 @@ function normaliseCard(document) {
     reactions,
     reacted,
     created_at: new Date(
-      data?.created_at?.seconds ?? // Added 16 Mar 2023
+      data?.created_at?.toMillis() ?? // Added 16 Mar 2023
         document._document.createTime.timestamp.seconds * 1000, // Bit of a hack
     ),
   };

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -120,7 +120,7 @@ function normaliseCard(document) {
     reactions,
     reacted,
     created_at: new Date(
-      data?.created_at?.toMillis?.() ?? // Added 16 Mar 2023
+      data?.created_at?.toMillis() ?? // Added 16 Mar 2023
         document._document.createTime.timestamp.seconds * 1000, // Bit of a hack
     ),
   };

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -120,7 +120,7 @@ function normaliseCard(document) {
     reactions,
     reacted,
     created_at: new Date(
-      data?.created_at?.toMillis() ?? // Added 16 Mar 2023
+      data?.created_at?.toMillis?.() ?? // Added 16 Mar 2023
         document._document.createTime.timestamp.seconds * 1000, // Bit of a hack
     ),
   };


### PR DESCRIPTION
## Summary

- `firestore.js`: switched `data.created_at.seconds` to `data.created_at.toMillis()` — `.seconds` is a Unix timestamp in seconds but `new Date()` expects milliseconds, so the Date was constructed 1000× too early
- `Menu.svelte`: replaced `new Date(card.created_at * 1000).toISOString()` with `card.created_at.toISOString()` — multiplying a Date object by 1000 calls `.valueOf()` (ms) then multiplies again, giving a timestamp 1000× too far in the future
- The two bugs cancelled each other for cards with a Firestore-stored `created_at` field, but produced year ~57,000 timestamps for older cards that fell through to the fallback path in `firestore.js`
- Adds a Cypress test asserting the exported `created_at` is within 24 hours of the current time

## Test plan

- [ ] Run existing `Menu.cy.js` suite — all tests pass
- [ ] New test "csv created_at timestamp is within 24 hours of the current time" passes
- [ ] Download a CSV manually and confirm the `created_at` column shows the correct date

🤖 Generated with [Claude Code](https://claude.com/claude-code)