### PR TITLE
fix: remove dead {:else} branch in Rank card list

### DIFF
--- a/src/components/Rank.svelte
+++ b/src/components/Rank.svelte
@@ -228,26 +228,18 @@
     style="color: {$colors[rank.data.color]}"
   ></div>
   <div class="h-100" bind:this={dropTarget} data-rank-id={rank.id}>
-    {#if $cards}
-      {#each sortedFilteredCards as card (card.id)}
-        <div
-          data-card-id={card.id}
-          animate:flip={{ duration: 200 }}
-          class="py-1"
-          data-drag={!(card.owner || $board.owner || $board.open_permission)
-            ? "false"
-            : "true"}
-        >
-          <Card {card} on:error color={rank.data.color} />
-        </div>
-      {/each}
-    {:else}
-      {#each sortedFilteredCards as card (card.id)}
-        <div animate:flip={{ duration: 200 }} class="py-2">
-          <Card {card} on:error color={rank.data.color} />
-        </div>
-      {/each}
-    {/if}
+    {#each sortedFilteredCards as card (card.id)}
+      <div
+        data-card-id={card.id}
+        animate:flip={{ duration: 200 }}
+        class="py-1"
+        data-drag={!(card.owner || $board.owner || $board.open_permission)
+          ? "false"
+          : "true"}
+      >
+        <Card {card} on:error color={rank.data.color} />
+      </div>
+    {/each}
     {#if !sortedFilteredCards || sortedFilteredCards.length === 0}
       <div
         class="text-secondary text-center mt-5 text-center float-right w-100"


### PR DESCRIPTION
## Summary

- Removes the unreachable `{:else}` branch inside the `{#if $cards}` block in `Rank.svelte`
- `$cards` is a Svelte store wrapping an array and is always truthy, so the `{:else}` branch could never execute
- The dead branch was also missing the `data-card-id` attribute required for drag-and-drop

## Background

The structure originated when the card list had two render paths: one using Svelte's `crossfade` `send`/`receive` transitions (with `data-card-id`), and a fallback without them. When crossfade was removed, the two paths were collapsed but the outer `{#if $cards}` / `{:else}` shell was accidentally left behind, orphaning the old fallback as dead code.

## Test plan

- [x] Verify cards render and drag-and-drop works normally on a board

🤖 Generated with [Claude Code](https://claude.com/claude-code)