### PR TITLE
chore: remove dead code identified in code review

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -4,39 +4,9 @@ Identified during code review on 2026-05-02.
 
 ---
 
-## Bugs
-
-### 1. `connectionLost` banner is dead UI
-**File:** `src/Board.svelte:45`
-`connectionLost` is declared as `false` and never set to `true`. The disconnection alerts at lines 289–303 and 350–363 can never appear. Either wire up a Firestore `onSnapshot` error handler to set it, or remove the dead UI.
-
-### 2. CSV export has wrong timestamp
-**File:** `src/components/Menu.svelte:91`
-`card.created_at` is already a `Date` object (constructed in `src/firestore.js:121`), but `downloadCSV` does `new Date(card.created_at * 1000)`. Coercing a `Date` via multiplication calls `.valueOf()`, producing a timestamp ~1000× too far in the future.
-**Fix:** replace with `card.created_at.toISOString()`.
-
-### 3. Missing `await` on `undoReact`
-**File:** `src/components/Card.svelte:107`
-```js
-if (card.reacted === emoji) {
-  return undoReact($board, card);  // no await — errors silently dropped
-}
-```
-The undo path is not awaited, so network errors are never caught or surfaced to the user.
-
-### 4. Dead `{:else}` branch in Rank card list
-**File:** `src/components/Rank.svelte:231`
-`{#if $cards}` always evaluates truthy — `$cards` is a Svelte store wrapping an array, never falsy. The `{:else}` block (lines 245–249) is unreachable and also missing the `data-card-id` attribute required for drag-and-drop.
-
-### 5. Board owner misses realtime sync when `open_permission` is active
-**File:** `src/Board.svelte:164`
-Only `!$board.owner` subscribes to Firestore board updates. When another `open_permission` user changes settings (e.g. toggles voting or obscure cards), the original owner never sees those changes until reload. The owner should also subscribe to remote board changes when `open_permission` is true.
-
----
-
 ## Incomplete Svelte 5 Migration
 
-### 6. `run()` from `svelte/legacy` used in 8 files
+### 1. `run()` from `svelte/legacy` used in 8 files
 Should be replaced with `$derived` or `$effect`:
 
 | File | Line | Usage | Replacement |
@@ -51,11 +21,11 @@ Should be replaced with `$derived` or `$effect`:
 | `src/components/Input.svelte` | 43 | CSS class string | `$derived` |
 | `src/components/Textarea.svelte` | 43 | CSS class + autoresize reset | `$derived` / `$effect` |
 
-### 7. `createEventDispatcher` and `on:event` syntax still used throughout
+### 2. `createEventDispatcher` and `on:event` syntax still used throughout
 Svelte 5 uses callback props instead. Files still using the legacy pattern:
 `Card.svelte`, `Rank.svelte`, `Menu.svelte`, `ReactDrawer.svelte`, `BoardRow.svelte`, `PasswordWall.svelte`, `BoardTable.svelte`, `Votes.svelte`, `IceBreaker.svelte`, `Header.svelte`, `RankOptions.svelte`
 
-### 8. `createBubbler` still used in primitive components
+### 3. `createBubbler` still used in primitive components
 **Files:** `src/components/Button.svelte:4`, `src/components/Input.svelte:4`, `src/components/Textarea.svelte:4`
 `createBubbler` is a legacy compat shim. Should be replaced with explicit callback props passed through to the underlying element.
 
@@ -63,7 +33,7 @@ Svelte 5 uses callback props instead. Files still using the legacy pattern:
 
 ## i18n Gap
 
-### 9. Entire "features" section of Splash.svelte is hardcoded English
+### 4. Entire "features" section of Splash.svelte is hardcoded English
 **File:** `src/Splash.svelte:146–226`
 Five feature cards and all their body text are raw English strings not wrapped in `$_()`. Affected content:
 - Card titles: "Anonymous", "Simple, Clean & Intuitive", "Free & Open Source", "No Logins!", "End to End Encryption"
@@ -75,44 +45,20 @@ Every non-English locale sees these in English. Keys should be added to `src/lan
 
 ## Dependencies
 
-### 10. `moment.js` (~300KB) used only for `fromNow()`
+### 5. `moment.js` (~300KB) used only for `fromNow()`
 **Files:** `src/components/BoardRow.svelte:91`, `src/components/LocaleSelect.svelte:21`, `src/i18n.js:2–19`
 The only user-facing use is a single relative timestamp. Can be replaced with the native `Intl.RelativeTimeFormat` API, eliminating a large dependency.
 
 Also: moment locales are imported for `es`, `ko`, `de`, `ru`, `uk` but **not** `pt_BR` or `tr` — so those two locales currently display English relative timestamps.
 
-### 11. Deprecated `event.keyCode`
+### 6. Deprecated `event.keyCode`
 **Files:** `src/components/Input.svelte:25,33`, `src/components/Textarea.svelte:27,35`
 `keyCode` is deprecated. Replace with `event.key === 'Enter'` and `event.key === 'Escape'`.
 
 ---
 
-## Dead Code
-
-### 12. `getCards` exported but never imported
-**File:** `src/api.js:108`
-Cards are fetched via Firestore realtime subscription. The REST `getCards` export is unused.
-
-### 13. Dead CSS in `Board.svelte`
-**File:** `src/Board.svelte:381–443`
-The following CSS rules reference elements or components no longer in the template:
-- `.add-button` (and its `@media` variant)
-- `.new-card-form`
-- `.overflow-x-hidden`
-- `:global(.svelte-tabs)`, `:global(.svelte-tabs__tab-list)`, `:global(.svelte-tabs li.svelte-tabs__tab)` — references a `svelte-tabs` component that no longer exists
-
-### 14. Dead CSS in `Rank.svelte`
-**File:** `src/components/Rank.svelte:263`
-`.header { text-align: center; }` is defined but the `.header` class is not used anywhere in the template.
-
-### 15. Commented-out delete board feature
-**File:** `src/components/Menu.svelte:124–131`, `286–297`
-Both `doDeleteBoard` and its menu item are commented out. Either complete and ship the feature or remove the dead code.
-
----
-
 ## Performance
 
-### 16. `EncryptedText` double async waterfall per render
+### 7. `EncryptedText` double async waterfall per render
 **File:** `src/components/EncryptedText.svelte`
 Every render awaits `decrypt()` then serially awaits `checkBoardPassword()`. The password check result doesn't change during a session — it could be derived once in a parent and passed as a prop, or memoized in a store.

--- a/src/Board.svelte
+++ b/src/Board.svelte
@@ -401,35 +401,9 @@
     border-right: 0.1em solid #495057;
   }
 
-  .add-button {
-    position: fixed;
-    bottom: 1em;
-    right: 1em;
-    width: 3em;
-    height: 3em;
-    z-index: 1038;
-  }
-
   .icon {
     width: 1.5em;
     height: 1.5em;
-  }
-
-  :global(.svelte-tabs) {
-    flex: 1 1 1em;
-    display: flex;
-    flex-direction: column;
-  }
-
-  :global(.svelte-tabs__tab-list) {
-    display: table;
-    table-layout: fixed;
-    width: 100%;
-  }
-
-  :global(.svelte-tabs li.svelte-tabs__tab) {
-    display: table-cell;
-    text-align: center;
   }
 
   input[type="radio"] {
@@ -445,25 +419,11 @@
     text-align: center;
   }
 
-  .overflow-x-hidden {
-    overflow-x: hidden;
-  }
-
-  .new-card-form {
-    z-index: 1039;
-  }
-
   .tab-buttons {
     z-index: 1040;
   }
 
   .min-vh-90 {
     min-height: 90vh;
-  }
-
-  @media (max-width: 768px) {
-    .add-button {
-      bottom: 6em;
-    }
   }
 </style>

--- a/src/api.js
+++ b/src/api.js
@@ -105,10 +105,6 @@ export async function createBoard(
   });
 }
 
-export async function getCards(boardId) {
-  return requestJson(`${api_host}/boards/${boardId}/cards`, common_options);
-}
-
 export async function createCard(boardId, rankId, text, author) {
   return requestJson(`${api_host}/boards/${boardId}/columns/${rankId}/cards`, {
     method: "POST",

--- a/src/components/Menu.svelte
+++ b/src/components/Menu.svelte
@@ -120,15 +120,6 @@
       error("error.network", err);
     }
   }
-
-  // async function doDeleteBoard() {
-  //   try {
-  //     await deleteBoard($board.id);
-  //     navigate("/");
-  //   } catch (err) {
-  //     error("error.board_delete", err);
-  //   }
-  // }
 </script>
 
 <Dropdown bind:isOpen toggle={() => (isOpen = !isOpen)}>
@@ -283,18 +274,6 @@
       </div>
       {$_("general.donate")}
     </DropdownItem>
-    <!-- {#if $board.owner}
-      <DropdownItem divider />
-      <DropdownItem data-name="delete=baord-button" on:click={doDeleteBoard}>
-        <div
-          class="d-inline-block icon text-danger position-relative"
-          style="top: -3px"
-        >
-          <Icons.delete size="1x" />
-        </div>
-        {$_("board.delete")}
-      </DropdownItem>
-    {/if} -->
   </DropdownMenu>
 </Dropdown>
 

--- a/src/components/Rank.svelte
+++ b/src/components/Rank.svelte
@@ -252,10 +252,6 @@
 </div>
 
 <style>
-  .header {
-    text-align: center;
-  }
-
   .icon {
     width: 1.5em;
     box-sizing: content-box;


### PR DESCRIPTION
## Summary

- Delete `getCards()` from `src/api.js` — unused since the March 2023 Firestore streaming migration replaced polling
- Remove 7 dead CSS rules from `src/Board.svelte` (`.add-button`, `.new-card-form`, `.overflow-x-hidden`, `:global(.svelte-tabs*)`) — orphaned since the June 2020 "No modals" and drag-and-drop refactors
- Remove dead `.header` CSS rule from `src/components/Rank.svelte`
- Remove commented-out `doDeleteBoard` function and menu item from `src/components/Menu.svelte` (disabled since March 2023; delete-from-board-listing still works via `BoardRow.svelte`)
- Update `IMPROVEMENTS.md` to remove resolved items (bugs 1–5 fixed in #197–#201, dead code 12–15 fixed here) and renumber remaining open items

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Board renders and card list displays correctly
- [x] Board menu opens and functions normally (no delete board option visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)