### PR TITLE
perf: memoize board password check across EncryptedText instances

### DIFF
--- a/cypress/e2e/Encryption.cy.js
+++ b/cypress/e2e/Encryption.cy.js
@@ -1,0 +1,59 @@
+/// <reference types="cypress" />
+
+context("Encryption", () => {
+  const boardPassword = "test-password-123";
+
+  before(() => {
+    cy.login();
+    cy.visit("/");
+    cy.get("[data-name=board-name-input]").type("Encrypted Test Board");
+    cy.get("[data-name=more-settings-button]").click();
+    cy.get("[data-name=encrypt-board-checkbox]").click();
+    cy.get("[data-name=board-password-input]").type(boardPassword);
+    cy.get("[data-name=create-button]").click();
+    cy.get("[data-name=create-button]:visible").should("have.length", 0);
+    cy.get("[data-name=rank]:visible")
+      .first()
+      .find("[data-name=card-text-input]")
+      .type("Secret card content");
+    cy.get("[data-name=rank]:visible")
+      .first()
+      .find("[data-name=card-author-input]")
+      .type("Secret Author{enter}");
+  });
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit("/");
+    cy.get("[data-name=board-list-button]").click();
+    cy.get("[data-name=board-row] td").first().click();
+  });
+
+  it("shows encrypted placeholder without a password", () => {
+    cy.get("[data-name=password-wall-input]").should("exist");
+    cy.get("[data-name=card]").should("not.exist");
+  });
+
+  it("decrypts card content after entering the correct password", () => {
+    cy.get("[data-name=password-wall-input]").type(boardPassword);
+    cy.get("[data-name=password-wall-unlock-button]").click();
+    cy.get("[data-name=password-wall-input]").should("not.exist");
+    cy.get("[data-name=card]:visible").should("have.length", 1);
+    cy.get("[data-name=card]:visible").should("not.contain", "(Encrypted)");
+    cy.get("[data-name=card]:visible").should("contain", "Secret card content");
+    cy.get("[data-name=card]:visible").should("contain", "Secret Author");
+  });
+
+  after(() => {
+    cy.login();
+    cy.intercept("boards").as("getBoards");
+    cy.visit("/");
+    cy.wait("@getBoards");
+    cy.get("[data-name=board-list-button]").click();
+    cy.get("[data-name=delete-button]").each(($el) => {
+      cy.wrap($el).click();
+      cy.get("[data-name=delete-confirm-button]").click();
+    });
+    cy.get("[data-name=board-table]").should("not.exist");
+  });
+});

--- a/src/components/Checkbox.svelte
+++ b/src/components/Checkbox.svelte
@@ -4,6 +4,8 @@
   const bubble = createBubbler();
   import clsx from "clsx";
 
+  import { filterDataKeys } from "../utils.js";
+
   let {
     class: className = "",
     disabled = false,
@@ -11,6 +13,7 @@
     label = "",
     addon = false,
     id = "id-" + Math.floor(Math.random() * 10000),
+    ...rest
   } = $props();
 
   let wrapperClasses = $derived(
@@ -18,12 +21,15 @@
   );
 
   let directClasses = $derived(clsx(className, { "form-check-input": !addon }));
+
+  let data = $derived(filterDataKeys(rest));
 </script>
 
 {#if label}
   <div class={wrapperClasses}>
     <input
       {id}
+      {...data}
       type="checkbox"
       class="custom-control-input"
       {disabled}
@@ -36,6 +42,7 @@
 {:else}
   <input
     {id}
+    {...data}
     type="checkbox"
     class={directClasses}
     {disabled}

--- a/src/components/CreateForm.svelte
+++ b/src/components/CreateForm.svelte
@@ -187,10 +187,12 @@
         <div class="input-group-text">
           <Checkbox
             addon
+            data-name="encrypt-board-checkbox"
             on:input={(i) => (passwordDisabled = !i.target.checked)}
           />
         </div>
         <Input
+          data-name="board-password-input"
           type={showPassword ? "text" : "password"}
           placeholder={$_("general.password")}
           bind:disabled={passwordDisabled}

--- a/src/components/EncryptedText.svelte
+++ b/src/components/EncryptedText.svelte
@@ -1,8 +1,8 @@
 <script>
   import { _ } from "svelte-i18n";
 
-  import { password, board } from "../store.js";
-  import { decrypt, checkBoardPassword } from "../encryption.js";
+  import { password, passwordValid } from "../store.js";
+  import { decrypt } from "../encryption.js";
 
   let { text } = $props();
 </script>
@@ -11,10 +11,8 @@
   {#await decrypt(text, $password)}
     …
   {:then string}
-    {#await checkBoardPassword($board, $password)}
-      …
-    {:then decrypted}
-      {#if !decrypted}{$_("general.encrypted")}{:else}{string}{/if}
-    {/await}
+    {#if $passwordValid === null}…{:else if $passwordValid}{string}{:else}{$_(
+        "general.encrypted",
+      )}{/if}
   {/await}
 {/if}

--- a/src/components/PasswordWall.svelte
+++ b/src/components/PasswordWall.svelte
@@ -43,6 +43,7 @@
       </p>
       <div class="input-group">
         <Input
+          data-name="password-wall-input"
           type={showPassword ? "text" : "password"}
           name="password"
           id="password"
@@ -63,6 +64,7 @@
       </div>
       <div class="text-end">
         <Button
+          data-name="password-wall-unlock-button"
           class="mt-1"
           color={$darkMode ? "dark" : "primary"}
           on:click={checkPassword}

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,6 @@
 import { derived, writable } from "svelte/store";
 import { Colors } from "./data";
+import { checkBoardPassword } from "./encryption.js";
 
 function createSet() {
   const { subscribe, set, update } = writable([]);
@@ -65,3 +66,11 @@ export const colorMode = derived(darkMode, ($darkMode) =>
 );
 
 export const colors = derived(colorMode, ($colorMode) => Colors[$colorMode]);
+
+export const passwordValid = derived(
+  [board, password],
+  ([$board, $password], set) => {
+    checkBoardPassword($board, $password).then(set);
+  },
+  null,
+);


### PR DESCRIPTION
## Summary
- `EncryptedText.svelte` was awaiting `checkBoardPassword($board, $password)` on every render, despite the result depending only on board+password — so N encrypted strings on a board meant N redundant async calls per render.
- Adds a `passwordValid` derived store computed once per `$board`/`$password` change, and reads it synchronously in `EncryptedText`. Also turns the previous serial `decrypt` → `checkBoardPassword` waterfall into parallel work.
- Adds `data-name` attributes to `PasswordWall`/`CreateForm` (and forwards `data-*` through `Checkbox`) so the new flow can be exercised in Cypress.
- Addresses item 7 from `IMPROVEMENTS.md`.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx cypress run --spec cypress/e2e/Encryption.cy.js` — both new tests pass
- [x] Regression: `Card.cy.js`, `Header.cy.js`, `IceBreaker.cy.js`, `CreateForm.cy.js` — all 11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)