### PR TITLE
docs: comprehensive codebase review findings

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,385 @@
+# Codebase Review: Issues & Improvements
+
+Findings from a comprehensive review of the retro.tools frontend. Covers Svelte components, JS modules, security, i18n, tests, and CI/CD. Each entry includes a file:line reference, description, and recommended fix.
+
+---
+
+## Bugs
+
+### B1 — Memory leak in dark mode media query listener (`src/App.svelte:20–34`)
+
+**Severity: High**
+
+The `change` listener on `prefersDarkScheme` is added as an anonymous arrow function on line 20, but the `onMount` cleanup on line 33 tries to remove `darkModeChangeListener` — a different function reference used for the colorMode subscription. The anonymous media-query listener is never removed, leaking on every unmount.
+
+```js
+// Current (line 20): listener added as anonymous function
+prefersDarkScheme.addEventListener("change", (e) => { ... });
+
+// Current (line 33): removes the WRONG function
+return () => {
+  unsubscribeDarkModeChange();
+  prefersDarkScheme.removeEventListener("change", darkModeChangeListener); // wrong ref
+};
+```
+
+**Fix:** Store the handler in a named variable and reference it in both `addEventListener` and `removeEventListener`.
+
+```js
+const handleSchemeChange = (e) => { ... };
+prefersDarkScheme.addEventListener("change", handleSchemeChange);
+return () => {
+  unsubscribeDarkModeChange();
+  prefersDarkScheme.removeEventListener("change", handleSchemeChange);
+};
+```
+
+---
+
+### B2 — ClipboardJS instance never stored or destroyed (`src/components/Menu.svelte:42`)
+
+**Severity: High**
+
+`new ClipboardJS("button")` runs at module scope (outside any lifecycle hook), so the instance is created but never stored or `.destroy()`-ed when the component unmounts. The `"button"` selector also matches all buttons in the document, including those not yet mounted.
+
+**Fix:** Move into `onMount`, store the instance, destroy it in the cleanup:
+
+```js
+import { onMount } from "svelte";
+let clipboard;
+onMount(() => {
+  clipboard = new ClipboardJS("[data-clipboard-text]");
+  return () => clipboard.destroy();
+});
+```
+
+---
+
+### B3 — Null dereference in drag `accepts` callback (`src/Board.svelte:62`)
+
+**Severity: High**
+
+```js
+accepts: (el, target) => {
+  return target.dataset.rankId !== $cards.find((c) => c.id === el.dataset.cardId).column;
+},
+```
+
+If the card is not found in `$cards` (e.g. the store is mid-update), `.column` throws a `TypeError` and crashes the drag handler.
+
+**Fix:** Guard against a missing card:
+
+```js
+accepts: (el, target) => {
+  const card = $cards.find((c) => c.id === el.dataset.cardId);
+  return card != null && target.dataset.rankId !== card.column;
+},
+```
+
+---
+
+### B4 — Null dereference in drag `drop` handler (`src/Board.svelte:80`)
+
+**Severity: High**
+
+Same pattern as B3. `const card = $cards.find(...)` is used immediately without a null check. If the card is absent, subsequent property access throws.
+
+**Fix:**
+
+```js
+drake.on("drop", async (el, target) => {
+  const card = $cards.find((c) => c.id === el.dataset.cardId);
+  if (!card) return;
+  ...
+});
+```
+
+---
+
+### B5 — `requestJson` doesn't check HTTP status (`src/api.js:16–18`)
+
+**Severity: Medium**
+
+```js
+async function requestJson(input, init) {
+  return (await fetch(input, init)).json();
+}
+```
+
+On a 4xx or 5xx response, `.json()` either throws a parse error (if the body isn't JSON) or silently decodes the error body as if it were valid data. Callers have no way to distinguish success from failure.
+
+**Fix:**
+
+```js
+async function requestJson(input, init) {
+  const response = await fetch(input, init);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  return response.json();
+}
+```
+
+---
+
+### B6 — Missing null guards in `normaliseCard` (`src/firestore.js:115–116`)
+
+**Severity: Medium**
+
+`data.column.id` and `data.owner.id` are accessed directly without checking that `column` or `owner` exist. If a Firestore document is missing either field (due to a partial write, schema migration, or corrupted data), this throws inside the `onSnapshot` callback and breaks all card subscriptions silently.
+
+**Fix:**
+
+```js
+column: data.column?.id ?? null,
+owner: data.owner?.id === get(uid),
+```
+
+---
+
+### B7 — Private Firestore SDK field access (`src/firestore.js:124`)
+
+**Severity: Medium**
+
+```js
+document._document.createTime.timestamp.seconds * 1000
+```
+
+`_document` is an internal, undocumented Firestore SDK field. It can silently change or disappear on any SDK update. The fallback is also non-obvious.
+
+**Fix:** Use `Date.now()` as the fallback rather than reaching into private internals:
+
+```js
+created_at: new Date(data?.created_at?.toMillis() ?? Date.now()),
+```
+
+---
+
+### B8 — Race condition in async derived store (`src/store.js:70–76`)
+
+**Severity: Medium**
+
+```js
+export const passwordValid = derived(
+  [board, password],
+  ([$board, $password], set) => {
+    checkBoardPassword($board, $password).then(set);
+  },
+  null,
+);
+```
+
+If `board` or `password` changes rapidly, multiple async calls can be in-flight simultaneously. Whichever resolves last wins — which may not be the most recent call. This can leave `passwordValid` set to a stale result.
+
+**Fix:** Cancel the previous promise by tracking a generation counter:
+
+```js
+export const passwordValid = derived(
+  [board, password],
+  ([$board, $password], set) => {
+    let cancelled = false;
+    checkBoardPassword($board, $password).then((v) => { if (!cancelled) set(v); });
+    return () => { cancelled = true; };
+  },
+  null,
+);
+```
+
+---
+
+## Security
+
+### S1 — Weak encryption: no key derivation, no authentication (`src/encryption.js:1–20`)
+
+**Severity: Critical**
+
+The encryption implementation has two fundamental weaknesses:
+
+1. **No key derivation**: The raw password string is passed directly to `AES.encrypt` as the key. crypto-js uses a non-standard, weak KDF (MD5-based EVP_BytesToKey) rather than PBKDF2/scrypt. This makes brute-force attacks significantly easier.
+2. **No authentication**: crypto-js uses AES-CBC, which has no integrity/authenticity guarantee. An attacker who can modify stored ciphertext can do so undetected.
+
+**Fix:** Replace with the Web Crypto API (built into all modern browsers, no dependency needed), using PBKDF2 for key derivation and AES-GCM for authenticated encryption:
+
+```js
+export async function encrypt(clearText, password) {
+  if (!password) return clearText;
+  const enc = new TextEncoder();
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const keyMaterial = await crypto.subtle.importKey("raw", enc.encode(password), "PBKDF2", false, ["deriveKey"]);
+  const key = await crypto.subtle.deriveKey(
+    { name: "PBKDF2", salt, hash: "SHA-256", iterations: 200_000 },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt"],
+  );
+  const ciphertext = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, enc.encode(clearText));
+  const out = new Uint8Array(salt.byteLength + iv.byteLength + ciphertext.byteLength);
+  out.set(salt, 0);
+  out.set(iv, salt.byteLength);
+  out.set(new Uint8Array(ciphertext), salt.byteLength + iv.byteLength);
+  return btoa(String.fromCharCode(...out));
+}
+```
+
+Note: migrating to AES-GCM is a breaking change for existing encrypted boards — a migration path (detecting old crypto-js format vs new) is required.
+
+---
+
+### S2 — Silent decryption failure returns `"?"` (`src/encryption.js:15–19`)
+
+**Severity: Medium**
+
+```js
+} catch {
+  return "?";
+}
+```
+
+Callers (e.g. the CSV export in `Menu.svelte`) cannot tell whether `"?"` is the actual decrypted content or a decryption failure. Wrong passwords, corrupted data, and tampering all look identical.
+
+**Fix:** Throw a typed error instead, and let callers handle it:
+
+```js
+} catch {
+  throw new Error("Decryption failed");
+}
+```
+
+---
+
+## Code Quality
+
+### Q1 — Conflicting Prettier configs (`.prettierrc` + `prettier.config.yaml`)
+
+**Severity: Medium**
+
+Both files exist in the repo root. Prettier's config search order means `.prettierrc` takes precedence and `prettier.config.yaml` is silently ignored. The YAML file contains the actual formatting rules (`singleQuote: true`, `semi: true`, `trailingComma: "es5"`, `tabWidth: 2`); the `.prettierrc` only has the plugin and Svelte parser override. This means Prettier CLI doesn't enforce single quotes or other style rules — they're only caught by ESLint's prettier plugin.
+
+**Fix:** Merge the YAML's rules into `.prettierrc` and delete `prettier.config.yaml`:
+
+```json
+{
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "plugins": ["prettier-plugin-svelte"],
+  "overrides": [
+    {
+      "files": "*.svelte",
+      "options": { "parser": "svelte" }
+    }
+  ]
+}
+```
+
+---
+
+### Q2 — Dead `moment` chunk in vite config (`vite.config.js:20–22`)
+
+**Severity: Low**
+
+```js
+if (id.includes("moment")) {
+  return "moment";
+}
+```
+
+`moment.js` was removed in commit `500d6ff` (replaced with `Intl.RelativeTimeFormat`). This chunk rule never matches anything and should be deleted.
+
+---
+
+### Q3 — Wrong German translation for `error.card_delete` (`src/lang/de.json:21`)
+
+**Severity: Low**
+
+```json
+"error.card_delete": "Fehler beim Entfernen des Boards!"
+```
+
+Says "Board" but should say "Karte" (card). The English source is "Card deletion failed!".
+
+**Fix:**
+
+```json
+"error.card_delete": "Fehler beim Entfernen der Karte!"
+```
+
+---
+
+### Q4 — Wrong Spanish translation for `error.card_delete` (`src/lang/es.json:21`)
+
+**Severity: Low**
+
+```json
+"error.card_delete": "¡Error al eliminar el tablero!"
+```
+
+Says "tablero" (board) but should say "tarjeta" (card).
+
+**Fix:**
+
+```json
+"error.card_delete": "¡Error al eliminar la tarjeta!"
+```
+
+---
+
+## CI/CD
+
+### C1 — Outdated GitHub Actions versions (`.github/workflows/CICD.yml:14, 47`)
+
+**Severity: Medium**
+
+Uses `actions/checkout@v1` and `actions/setup-node@v1`. Both are several major versions behind (current: v4). v1 uses deprecated Node.js runtimes and has known deprecation warnings that will eventually become errors.
+
+**Fix:** Bump to current versions:
+
+```yaml
+- uses: actions/checkout@v4
+- uses: actions/setup-node@v4
+  with:
+    node-version: 22.x
+```
+
+---
+
+### C2 — Non-LTS Node.js version (`.github/workflows/CICD.yml:15, 50`)
+
+**Severity: Low**
+
+`node-version: 25.x` is experimental/current, not an LTS release. Using a non-LTS version in CI risks unexpected breakage when minor releases ship.
+
+**Fix:** Use `22.x` (Active LTS) or `20.x` (Maintenance LTS).
+
+---
+
+### C3 — Firefox testing disabled (`.github/workflows/CICD.yml:39–40`)
+
+**Severity: Low**
+
+```yaml
+# - firefox
+```
+
+The app is only tested on Chrome. Firefox has diverged on several CSS and JS behaviours that Chrome tolerates. Re-enabling Firefox in the matrix would catch cross-browser regressions before they reach users.
+
+---
+
+## Missing Test Coverage
+
+### T1 — Emoji reactions
+
+No Cypress spec covers the `react`/`undoReact` flow (`src/api.js:162–175`). Suggested spec: `cypress/e2e/Reactions.cy.js` — add reaction to a card, verify count, remove reaction, verify count decrements.
+
+### T2 — Max votes enforcement
+
+No test verifies that voting is blocked when `max_votes` is reached. The cap is enforced server-side, but a test that creates a board with `max_votes: 1`, casts a vote, and confirms the vote button is disabled (or vote count stays at 1) would catch regressions.
+
+### T3 — Board-not-found navigation
+
+`Board.svelte:134` navigates to `/not-found` when the API returns a 404. No spec covers this path. A test that navigates to a non-existent board ID and asserts the not-found page renders would close this gap.
+
+### T4 — Drag-and-drop in obscure mode
+
+`DragCard.cy.js` tests dragging under normal conditions. No test combines obscured cards with drag-and-drop, which exercises a different rendering path in `Card.svelte`.


### PR DESCRIPTION
## Summary

- Adds `IMPROVEMENTS.md` documenting findings from a full codebase review
- Covers bugs, security issues, code quality, CI/CD, and missing test coverage
- Each entry includes a file:line reference, description, and recommended fix

## What's in the review

**Bugs (8):**
- Memory leak in dark mode media query listener (`App.svelte:20–34`)
- ClipboardJS instance never destroyed (`Menu.svelte:42`)
- Null dereference in dragula `accepts` and `drop` callbacks (`Board.svelte:62, 80`)
- `requestJson` doesn't check HTTP status before parsing (`api.js:16–18`)
- Missing null guards on `data.column` / `data.owner` in `normaliseCard` (`firestore.js:115–116`)
- Private Firestore SDK field access (`firestore.js:124`)
- Race condition in async derived `passwordValid` store (`store.js:70–76`)

**Security (2):**
- `crypto-js` AES with raw password as key (no PBKDF2), AES-CBC (no auth tag) — `encryption.js`
- Silent `"?"` return on decryption failure masks wrong-password and tampering — `encryption.js`

**Code Quality (4):**
- Conflicting Prettier configs (`.prettierrc` takes precedence, `prettier.config.yaml` silently ignored)
- Dead `moment` chunk in `vite.config.js` (moment.js was removed in #203)
- Wrong translations for `error.card_delete` in `de.json` and `es.json` (says "board" instead of "card")

**CI/CD (3):**
- `actions/checkout@v1` / `actions/setup-node@v1` are outdated (current: v4)
- `node-version: 25.x` is not LTS — should use `22.x`
- Firefox testing is commented out

**Missing Tests (4):**
- Emoji reactions flow
- Max votes enforcement
- Board-not-found navigation
- Drag-and-drop in obscure mode

## Test plan

- [x] Read through `IMPROVEMENTS.md` and verify file:line references are accurate
- [x] No code changes in this PR — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)