### PR TITLE
perf: improve LCP by parallelising board load and caching decrypts

### DIFF
--- a/src/Board.svelte
+++ b/src/Board.svelte
@@ -142,47 +142,33 @@
     }
 
     board.set(b);
-    ranks.set(await getRanks(boardId));
-    await checkPassword();
 
-    // Show first rank initially (by position, not API order)
-    const firstRank = [...$ranks].sort((a, b) => a.position - b.position)[0];
-    if (firstRank) $focusedRank = firstRank.id;
-
-    // Subscribe to local changes to $board so we can post updates.
-    // Compare updated boards to their last known value
-    // to ensure we don't send supurfluous calls.
+    // Compare updated boards to their last known value to ensure we don't send
+    // superfluous calls. Declared before subscribeToBoard so the firestore
+    // callback closes over the same reference as the local board.subscribe.
     let previousBoard = { ...$board };
-    if ($board.owner || $board.open_permission) {
-      unsubscribeLocalBoard = board.subscribe((b) => {
-        if (!compareBoards(previousBoard, b)) {
-          updateBoard(b).catch((err) => error('error.updating_settings', err));
-        }
-        previousBoard = { ...b };
-      });
-    }
 
-    // Non-owners subscribe to remote changes to stay in sync.
-    // Owners also subscribe when open_permission is active so they see changes made by other permitted users.
-    // Update previousBoard before setting the store to prevent echo-back pushes.
-    if (!$board.owner || $board.open_permission) {
-      unsubscribeBoard = await subscribeToBoard(
-        boardId,
-        (b) => {
-          previousBoard = { ...b };
-          board.set(b);
-        },
-        () => {
-          navigate('/not-found');
-        },
-        () => {
-          connectionLost = true;
-        }
-      );
-    }
-
-    // Subscribe to card updates
-    unsubscribeCards = await subscribeToCards(
+    // Kick off REST + firestore subscription setup in parallel. Each
+    // subscribeToX call internally awaits signIn(), which is now memoised so
+    // concurrent callers share a single auth round-trip.
+    const ranksTask = getRanks(boardId);
+    const subscribeBoardTask =
+      !$board.owner || $board.open_permission
+        ? subscribeToBoard(
+            boardId,
+            (b) => {
+              previousBoard = { ...b };
+              board.set(b);
+            },
+            () => {
+              navigate('/not-found');
+            },
+            () => {
+              connectionLost = true;
+            }
+          )
+        : Promise.resolve(null);
+    const subscribeCardsTask = subscribeToCards(
       boardId,
       (card) => cards.replace(card.id, card),
       (card) => cards.replace(card.id, card),
@@ -191,9 +177,7 @@
         connectionLost = true;
       }
     );
-
-    // Subscribe to rank updates
-    unsubscribeRanks = await subscribeToRanks(
+    const subscribeRanksTask = subscribeToRanks(
       boardId,
       (rank) => ranks.replace(rank.id, rank),
       (rank) => ranks.replace(rank.id, rank),
@@ -208,10 +192,35 @@
       }
     );
 
+    ranks.set(await ranksTask);
+    await checkPassword();
+
+    // Show first rank initially (by position, not API order)
+    const firstRank = [...$ranks].sort((a, b) => a.position - b.position)[0];
+    if (firstRank) $focusedRank = firstRank.id;
+
+    // Subscribe to local changes to $board so we can post updates.
+    if ($board.owner || $board.open_permission) {
+      unsubscribeLocalBoard = board.subscribe((b) => {
+        if (!compareBoards(previousBoard, b)) {
+          updateBoard(b).catch((err) => error('error.updating_settings', err));
+        }
+        previousBoard = { ...b };
+      });
+    }
+
     window.addEventListener('offline', handleOffline);
     window.addEventListener('online', handleOnline);
 
+    // Don't gate the initial paint on subscription registration; cards/ranks
+    // will populate via the in-flight subscriptions as their snapshots arrive.
     busy = false;
+
+    [unsubscribeBoard, unsubscribeCards, unsubscribeRanks] = await Promise.all([
+      subscribeBoardTask,
+      subscribeCardsTask,
+      subscribeRanksTask,
+    ]);
   });
 
   function handleOffline() {
@@ -258,10 +267,7 @@
       <PasswordWall onaccepted={checkPassword} />
     </div>
   {:else}
-    <div
-      transition:fade={{ duration: 200 }}
-      class="d-none d-lg-block scroll h-100"
-    >
+    <div class="d-none d-lg-block scroll h-100">
       <IceBreaker class="w-50" />
       <div
         class="d-none d-lg-flex justify-content-center overflow-hidden
@@ -282,10 +288,7 @@
       </div>
     </div>
 
-    <div
-      transition:fade={{ duration: 200 }}
-      class="d-block flex-grow-1 d-lg-none scroll"
-    >
+    <div class="d-block flex-grow-1 d-lg-none scroll">
       <IceBreaker class="w-100" />
       {#each sortedRanks as rank, i (rank.id)}
         {#if rank.id == $focusedRank}

--- a/src/encryption.js
+++ b/src/encryption.js
@@ -48,9 +48,40 @@ export async function encrypt(clearText, password = '') {
   return toBase64(combined.buffer);
 }
 
+// Cache decryption results so repeated re-renders of the same ciphertext don't
+// re-run PBKDF2 (200k iterations) per card. Bounded so long sessions don't leak.
+const DECRYPT_CACHE_LIMIT = 1024;
+const decryptCache = new Map();
+
+function cacheGet(key) {
+  if (!decryptCache.has(key)) return undefined;
+  const value = decryptCache.get(key);
+  decryptCache.delete(key);
+  decryptCache.set(key, value);
+  return value;
+}
+
+function cacheSet(key, value) {
+  decryptCache.set(key, value);
+  if (decryptCache.size > DECRYPT_CACHE_LIMIT) {
+    decryptCache.delete(decryptCache.keys().next().value);
+  }
+}
+
 export async function decrypt(cipherText, password = '') {
   if (password.length === 0) return cipherText;
 
+  const cacheKey = `${password}\0${cipherText}`;
+  const cached = cacheGet(cacheKey);
+  if (cached) return cached;
+
+  const promise = decryptUncached(cipherText, password);
+  cacheSet(cacheKey, promise);
+  promise.catch(() => decryptCache.delete(cacheKey));
+  return promise;
+}
+
+async function decryptUncached(cipherText, password) {
   // Legacy path: crypto-js AES-CBC (read-only, for boards created before the migration)
   if (cipherText.startsWith(LEGACY_PREFIX)) {
     const result = AES.decrypt(cipherText, password).toString(Crypto.enc.Utf8);

--- a/src/firestore.js
+++ b/src/firestore.js
@@ -58,16 +58,23 @@ async function verifyToken() {
   uid.set(decodedToken.uid);
 }
 
+// Dedup concurrent signIn() calls so that parallel subscribers don't each hit
+// /auth and signInWithCustomToken; the in-flight promise is shared and cleared
+// once it settles, so subsequent calls re-verify the token.
+let signInPromise = null;
 export async function signIn() {
-  const auth = getAuth();
-
-  await verifyToken();
-
-  if (auth.currentUser) {
-    return;
+  if (signInPromise) return signInPromise;
+  signInPromise = (async () => {
+    const auth = getAuth();
+    await verifyToken();
+    if (auth.currentUser) return;
+    await signInWithCustomToken(auth, get(firebaseToken));
+  })();
+  try {
+    return await signInPromise;
+  } finally {
+    signInPromise = null;
   }
-
-  await signInWithCustomToken(auth, get(firebaseToken));
 }
 
 function normaliseBoard(document) {


### PR DESCRIPTION
## Summary

The Core Web Vitals report flags the card body (`div.p-1.w-100.pre-wrap` in `Card.svelte`) as the dominant LCP element. Three changes shorten the critical path to its first paint:

- **Parallelise `Board.svelte` `onMount`.** Previously it serialised six awaits — `getBoard` → `getRanks` → `checkPassword` → three `subscribeToX` calls (each with its own `signIn` round-trip) — before flipping `busy = false`. Now `getRanks` and the three firestore subscription handshakes run concurrently, and `busy = false` flips as soon as ranks REST + password check resolve. Subscriptions complete in the background; cards/ranks populate as their first snapshots arrive.
- **Drop the 200ms `transition:fade` on the cards container.** Pure win — that 200ms was being added on top of the LCP every load.
- **Memoise `signIn()` in `firestore.js`** so the three concurrent subscribers share one `/auth` + `signInWithCustomToken` round-trip instead of racing three.
- **Cache `decrypt()` results in `encryption.js`** (LRU, bounded at 1024 entries) so re-renders of the same ciphertext don't redo PBKDF2's 200k iterations. Helps encrypted boards on every reactive update after the first paint.

Two further ideas from the analysis were deferred as too invasive for this PR: pre-decrypting cards eagerly into the store, and moving PBKDF2 off the main thread via Web Workers.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx cypress run` — full local suite (86 tests across 19 specs) passes, including `Encryption.cy.js`, `ConnectionLost.cy.js`, `OwnerRealtimeSync.cy.js`, `OpenPermission.cy.js`
- [ ] Verify in production that the LCP "Element" breakdown shifts from Poor toward Good for the card body selector

https://claude.ai/code/session_01CbPv23BpW2H57tvRh7fxqQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbPv23BpW2H57tvRh7fxqQ)_